### PR TITLE
Remove use of Pkg.BinaryPlatforms types for dispatch

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,3 +28,9 @@ TOML = "1"
 Tar = "1"
 p7zip_jll = "17.4"
 julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/src/AppBundler.jl
+++ b/src/AppBundler.jl
@@ -1,8 +1,11 @@
 module AppBundler
 
 # using Infiltrator
-import Pkg.BinaryPlatforms: Linux, Windows, MacOS
 using Scratch
+
+const Linux = Val{:linux}
+const Windows = Val{:windows}
+const MacOS = Val{:macos}
 
 DOWNLOAD_CACHE = ""
 

--- a/src/deps.jl
+++ b/src/deps.jl
@@ -2,7 +2,9 @@ import Downloads
 import Artifacts
 
 import Pkg
-import Base.BinaryPlatforms: AbstractPlatform, Platform, os, arch, wordsize
+import Base.BinaryPlatforms: AbstractPlatform, Platform, os, arch, wordsize, HostPlatform
+
+using Base.Sys: isapple, islinux, iswindows
 
 function retrieve_packages(app_dir, packages_dir; with_splash_screen=false)
 
@@ -79,41 +81,19 @@ function retrieve_artifacts(platform::AbstractPlatform, modules_dir, artifacts_d
 end
 
 
-ismacos(platform::AbstractPlatform) = os(platform) == "macos"
-islinux(platform::AbstractPlatform) = os(platform) == "linux" 
-iswindows(platform::AbstractPlatform) = os(p,atform) == "windows"
+const ismacos = Sys.isapple
 
-function platform_type(platform::Platform)
-    if islinux(platform)
-
-        return Linux(Symbol(arch(platform)))
-
-    elseif ismacos(platform)
-
-        return MacOS(Symbol(arch(platform)))
-
-    elseif iswindows(platform)
-        
-        return Windows(Symbol(platform))
-
-    else
-        return platform
-    end
+function platform_type(platform::AbstractPlatform)
+    return Val(Symbol(os(platform)))
 end
 
 
-function HostPlatform()
-
-    platform = Base.BinaryPlatforms.HostPlatform()
-
-    return platform_type(platform)
+function julia_download_url(platform::AbstractPlatform, version::VersionNumber)
+    julia_download_url(platform_type(platform), platform, version)
 end
 
 
-julia_download_url(platform::Platform, version::VersionNumber) = julia_download_url(platform_type(platform), version)
-
-
-function julia_download_url(platform::Linux, version::VersionNumber)
+function julia_download_url(::Linux, platform::AbstractPlatform, version::VersionNumber)
 
     if arch(platform) == :x86_64
 
@@ -136,7 +116,7 @@ function julia_download_url(platform::Linux, version::VersionNumber)
 end
 
 
-function julia_download_url(platform::MacOS, version::VersionNumber)
+function julia_download_url(::MacOS, platform::AbstractPlatform, version::VersionNumber)
 
     if arch(platform) == :x86_64
 
@@ -159,7 +139,7 @@ function julia_download_url(platform::MacOS, version::VersionNumber)
 end
 
 
-function julia_download_url(platform::Windows, version::VersionNumber)
+function julia_download_url(::Windows, platform::AbstractPlatform, version::VersionNumber)
 
     folder = "winnt/x$(wordsize(platform))"
     archive_name = "julia-$(version)-win$(wordsize(platform)).zip"

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,4 +1,8 @@
-function bundle_app(platform::MacOS, source, destination; julia_version = VERSION, with_splash_screen = nothing)
+function bundle_app(platform::AbstractPlatform, source, destination; julia_version = VERSION, with_splash_screen = nothing)
+    bundle_app(platform_type(platform), platform, source, destination; julia_verison, with_splash_screen)
+end
+
+function bundle_apps(::MacOS, platform::AbstractPlatform, source, destination; julia_version = VERSION, with_splash_screen = nothing)
 
     rm(destination, recursive=true, force=true)
 
@@ -42,7 +46,7 @@ function bundle_app(platform::MacOS, source, destination; julia_version = VERSIO
 end
 
 
-function bundle_app(platform::Linux, source, destination; julia_version = VERSION, compress::Bool = isext(destination, ".snap"))
+function bundle_app(::Linux, platform::AbstractPlatform, source, destination; julia_version = VERSION, compress::Bool = isext(destination, ".snap"))
 
     rm(destination, recursive=true, force=true)
 
@@ -91,7 +95,7 @@ function bundle_app(platform::Linux, source, destination; julia_version = VERSIO
 end
 
 
-function bundle_app(platform::Windows, source, destination; julia_version = VERSION, with_splash_screen=nothing, compress::Bool = isext(destination, ".zip"))
+function bundle_app(::Windows, platform::AbstractPlatform, source, destination; julia_version = VERSION, with_splash_screen=nothing, compress::Bool = isext(destination, ".zip"))
 
     rm(destination, recursive=true, force=true)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,13 +3,13 @@ import Pkg.BinaryPlatforms: Linux, Windows, MacOS
 
 using Test
 
-@test julia_download_url(Windows(:x86_64), v"1.9.3") == "https://julialang-s3.julialang.org/bin/winnt/x64/1.9/julia-1.9.3-win64.zip"
+@test julia_download_url(Windows(:x86_64), v"1.9.3") == "winnt/x64/1.9/julia-1.9.3-win64.zip"
 
-@test julia_download_url(Linux(:x86_64, libc=:glibc), v"1.9.3") == "https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz"
-@test julia_download_url(Linux(:aarch64), v"1.9.3") == "https://julialang-s3.julialang.org/bin/linux/aarch64/1.9/julia-1.9.3-linux-aarch64.tar.gz"
+@test julia_download_url(Linux(:x86_64, libc=:glibc), v"1.9.3") == "linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz"
+@test julia_download_url(Linux(:aarch64), v"1.9.3") == "linux/aarch64/1.9/julia-1.9.3-linux-aarch64.tar.gz"
 
-@test julia_download_url(MacOS(:x86_64), v"1.9.3") == "https://julialang-s3.julialang.org/bin/mac/x64/1.9/julia-1.9.3-mac64.tar.gz"
-@test julia_download_url(MacOS(:aarch64), v"1.9.3") == "https://julialang-s3.julialang.org/bin/mac/aarch64/1.9/julia-1.9.3-macaarch64.tar.gz"
+@test julia_download_url(MacOS(:x86_64), v"1.9.3") == "mac/x64/1.9/julia-1.9.3-mac64.tar.gz"
+@test julia_download_url(MacOS(:aarch64), v"1.9.3") == "mac/aarch64/1.9/julia-1.9.3-macaarch64.tar.gz"
 
 #https://julialang-s3.julialang.org/bin/mac/aarch64/1.9/julia-1.9.3-macaarch64.tar.gz
 #https://julialang-s3.julialang.org/bin//mac/aarch64/1.9/julia-1.9.2-macaarch64.tar.gz


### PR DESCRIPTION
Fix #4

Basically, we want to remove use of the Linux, Windows, and MacOS types from Pkg.BinaryPlatforms.

Instead, we dispatch on `Val(Symbol(Base.BinaryPlatforms.os(platform)))`. This allows us to
keep the current dispatch pattern and be backwards compatible with the use of
`Pkg.BinaryPlatforms.{Linux, Windows, MacOS}`. However, we no longer rely on those types for dispatch.
