### PR TITLE
feat: publish AppBundler distributions through juliaup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0]
+
+### Added
+
+- `Tarball` bundle format producing a relocatable, unsigned `.tar.gz` for Linux, macOS and Windows,
+  with `install.sh` / `install.ps1`, a `bin/` launcher and a `.desktop` entry
+  ([#36](https://github.com/PeaceFounder/AppBundler.jl/pull/36)).
+- `--target-bundle=tarball` and `--target-os` command line options ([#36](https://github.com/PeaceFounder/AppBundler.jl/pull/36)).
+- `juliaimg_strip_debug` and `juliaimg_strip_docs` preferences for smaller images
+  ([#36](https://github.com/PeaceFounder/AppBundler.jl/pull/36)).
+- `AppBundler.Juliaup` module for publishing distributions through `juliaup`
+  ([#43](https://github.com/PeaceFounder/AppBundler.jl/issues/43)). It writes the version database
+  for all 13 client target triples plus the four `*DBVERSION` pointer files, mirrors the upstream
+  database so stock channels keep working, and resolves the database version above the public one so
+  clients do not silently ignore it.
+- `appbundler juliaup <project_dir>` command building that static site, and
+  `AppBundler.install_juliaup_workflow()` installing a GitHub Actions workflow that builds the
+  tarballs, attaches them to the release and deploys the database to GitHub Pages.
+- Client wrappers (`<app>-juliaup`, `<app>-julia`, and PowerShell equivalents) that point
+  `JULIAUP_SERVER` at the distribution and isolate `JULIAUP_DEPOT_PATH`, leaving a stock `juliaup`
+  installation untouched.
+- Documentation for the whole workflow in `docs/src/juliaup.md`, including the two silent failure
+  modes: a database version at or below the public one is ignored without any diagnostic, and a
+  client on `dev` or `releasepreview` reads a different pointer file.
+- `llms.txt` and `llms-full.txt` generated with the documentation.
+
+### Changed
+
+- A tarball's canonical name now carries the operating system
+  (`<app>-<version>-<os>-<arch>.tar.gz`). Without it a release matrix uploads one archive per
+  platform under the same asset name and the `juliaup` database cannot tell them apart.
+
+### Fixed
+
+- `TarPack.pack` reported `ArgumentError: Collection has multiple elements` instead of its own
+  explanatory error when the staging directory held more than one entry.
+- `--target-bundle=tarball` raised a `MethodError` when combined with the `juliac` bundler; a
+  `JuliaCBundle` can now be packaged as a tarball like the other formats.
+
+## [1.0.1]
+
+Releases up to and including 1.0.1 predate this changelog; see the
+[commit history](https://github.com/PeaceFounder/AppBundler.jl/commits/main) for details.
+
+[Unreleased]: https://github.com/PeaceFounder/AppBundler.jl/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/PeaceFounder/AppBundler.jl/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/PeaceFounder/AppBundler.jl/releases/tag/v1.0.1

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -29,3 +29,11 @@ juliaimg_sysimg = []
 juliaimg_selective_assets = false
 
 juliac_trim = false
+
+# Publishing through juliaup. `juliaup_server` is the https base url the version database is
+# served from and is what the client wrappers export as JULIAUP_SERVER. `juliaup_asset_base`
+# is where the tarballs live: relative keeps the database portable across hosts, an absolute
+# url points elsewhere, such as a GitHub releases page.
+juliaup_server = ""
+juliaup_asset_base = "assets"
+juliaup_mirror = true

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AppBundler"
 uuid = "40eb83ae-c93a-480c-8f39-f018b568f472"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Janis Erdmanis <janiserdmanis@protonmail.ch>"]
 
 [workspace]
@@ -18,6 +18,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Makemsix_jll = "92e7c7cf-2c17-5ab8-9563-5ab5b2fcee8a"
@@ -48,6 +49,7 @@ FileIO = "1.17.0"
 ImageCore = "0.10.5"
 ImageIO = "0.6.9"
 ImageTransformations = "0.10.2"
+JSON = "1"
 LibGit2 = "1.11.0"
 Libdl = "1.11.0"
 Makemsix_jll = "1.7.241"

--- a/docs/llms.jl
+++ b/docs/llms.jl
@@ -1,0 +1,54 @@
+# Generates llms.txt and llms-full.txt alongside the built documentation, following the
+# https://llmstxt.org convention: llms.txt is an index of the pages, llms-full.txt is their full
+# text concatenated. Both are written into the build directory so they are deployed with the site.
+
+const SITE = "https://peacefounder.github.io/AppBundler.jl"
+
+const SUMMARY = """
+AppBundler bundles Julia applications into platform installers — DMG on macOS, MSIX on Windows, \
+Snap on Linux — as well as relocatable tarballs, and publishes them as distributions installable \
+through juliaup.
+"""
+
+function page_title(path, fallback)
+
+    for line in eachline(path)
+        startswith(line, "# ") && return strip(line[3:end])
+    end
+
+    return fallback
+end
+
+function generate_llms_txt(build_dir, source_dir, pages)
+
+    entries = Tuple{String, String, String}[] # title, url, source path
+
+    for (label, file) in pages
+        path = joinpath(source_dir, file)
+        isfile(path) || continue
+        title = label == "Overview" ? label : page_title(path, label)
+        push!(entries, (title, "$SITE/$(replace(file, ".md" => ""))/", path))
+    end
+
+    open(joinpath(build_dir, "llms.txt"), "w") do io
+        println(io, "# AppBundler.jl\n")
+        println(io, "> ", strip(SUMMARY), "\n")
+        println(io, "## Documentation\n")
+        for (title, url, _) in entries
+            println(io, "- [$title]($url)")
+        end
+    end
+
+    open(joinpath(build_dir, "llms-full.txt"), "w") do io
+        println(io, "# AppBundler.jl\n")
+        println(io, "> ", strip(SUMMARY), "\n")
+        for (title, url, path) in entries
+            println(io, "\n\n---\n")
+            println(io, "# $title\n")
+            println(io, "Source: $url\n")
+            println(io, read(path, String))
+        end
+    end
+
+    return
+end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -25,6 +25,17 @@ if !isfile(index_path) || String(read(index_path)) != index_content
     write(index_path, index_content)
 end
 
+include("llms.jl")
+
+const PAGES = [
+    "Overview" => "index.md",
+    "Customization" => "customization.md",
+    "Deployment" => "deployment.md", # codesigning, GitHub CI,
+    "Juliaup" => "juliaup.md",
+    "Troubleshooting" => "troubleshooting.md",
+    "Reference" => "reference.md" # Here I could also give an overview of the internal API on how it composes. Perhaps I shall madke that as documentation for the module here.
+]
+
 makedocs(
     sitename = "AppBundler.jl",
     repo = Documenter.Remotes.GitHub("PeaceFounder", "AppBundler.jl"),
@@ -33,14 +44,10 @@ makedocs(
     checkdocs = :public,
     modules = [AppBundler],
     checkdocs_ignored_modules = [AppBundler.DSStore, AppBundler.HFS],
-    pages = [
-        "Overview" => "index.md",
-        "Customization" => "customization.md",
-        "Deployment" => "deployment.md", # codesigning, GitHub CI,
-        "Troubleshooting" => "troubleshooting.md",
-        "Reference" => "reference.md" # Here I could also give an overview of the internal API on how it composes. Perhaps I shall madke that as documentation for the module here.
-    ]
+    pages = PAGES
 )
+
+generate_llms_txt(joinpath(@__DIR__, "build"), joinpath(@__DIR__, "src"), PAGES)
 
 deploydocs(repo = "github.com/PeaceFounder/AppBundler.jl.git")
 

--- a/docs/src/juliaup.md
+++ b/docs/src/juliaup.md
@@ -1,0 +1,177 @@
+# Juliaup
+
+Installers are the right shape for a desktop application, but a bundled Julia *distribution* — a
+runtime with your packages already baked in — is better delivered the way Julia itself is: through
+`juliaup`. Users then get
+
+```
+juliaup add myapp-1.2.0
+julia +myapp-1.2.0
+```
+
+and a single command to move to the next release.
+
+This needs no fork of `juliaup` and no dedicated infrastructure. `juliaup` downloads from whatever
+host `JULIAUP_SERVER` points at, so publishing a distribution is a matter of putting a handful of
+static files somewhere — GitHub Pages is enough — while the tarballs themselves stay on your
+releases page. This is the same approach JuliaHub uses to distribute Dyad.
+
+## What juliaup actually does
+
+`juliaup add <channel>` makes three requests, and only the first two touch your site:
+
+1. `GET <server>/juliaup/RELEASECHANNELDBVERSION` — one line, the number of the current database.
+2. `GET <server>/juliaup/versiondb/versiondb-<dbversion>-<target>.json` — the database, cached
+   locally afterwards.
+3. `GET <UrlPath>` — the tarball, at the path the database recorded for the resolved version.
+
+Steps between those are local lookups: the channel resolves to a full version string in
+`AvailableChannels`, which resolves to a `UrlPath` in `AvailableVersions`. The archive is then
+unpacked into `~/.julia/juliaup/julia-<fullversion>/`.
+
+`UrlPath` is resolved against the server base, which is what makes both layouts possible:
+
+- a **relative** path (`assets/myapp-1.2.0-linux-x86_64.tar.gz`) keeps the database portable — move
+  the whole site to another host and nothing has to be rewritten;
+- an **absolute** url points somewhere else entirely, so a database on GitHub Pages can serve
+  tarballs from your GitHub releases page without a single byte passing through Pages.
+
+## Publishing
+
+Build a tarball for each platform, then publish the database:
+
+```
+appbundler build . --target-bundle=tarball --build-dir=build
+appbundler juliaup . --build-dir=site \
+    --server=https://acme.github.io/myapp \
+    --asset-base=https://github.com/acme/myapp/releases/download/v1.2.0 \
+    --platform=linux/x86_64 --platform=macos/aarch64 \
+    --wrappers
+```
+
+which writes
+
+```
+site/juliaup/DBVERSION
+site/juliaup/RELEASECHANNELDBVERSION
+site/juliaup/RELEASEPREVIEWCHANNELDBVERSION
+site/juliaup/DEVCHANNELDBVERSION
+site/juliaup/versiondb/versiondb-<dbversion>-<target>.json   (13 files)
+site/wrappers/myapp-juliaup, myapp-julia, and the PowerShell equivalents
+```
+
+Serve that over HTTPS and the distribution is installable.
+
+The equivalent Julia API is [`AppBundler.Juliaup.publish`](@ref):
+
+```julia
+using AppBundler
+
+dist = Juliaup.JuliaupDistribution(".";
+                                   server = "https://acme.github.io/myapp",
+                                   asset_base = "https://github.com/acme/myapp/releases/download/v1.2.0")
+
+Juliaup.publish(dist, "site"; assets = [(:linux, :x86_64), (:macos, :aarch64)])
+```
+
+## Mirroring
+
+By default AppBundler *mirrors*: it downloads the upstream database, merges your channels into it,
+and republishes the result. Your users keep `release`, `lts` and every stock channel while pointed
+at your server. This is what JuliaHub does — their linux-x64 database is the public one plus their
+own entries.
+
+Pass `--no-mirror` to publish your channels alone. That is the right choice for an air-gapped site,
+where reaching `julialang-s3.julialang.org` at publish time is not possible, at the cost of stock
+Julia channels no longer resolving for anyone using your server.
+
+## Continuous delivery
+
+`AppBundler.install_juliaup_workflow()` drops a GitHub Actions workflow into
+`.github/workflows/Juliaup.yml`. It builds a tarball on a matching runner per platform, attaches
+them to the release, and deploys the database to GitHub Pages. Enable Pages for the repository with
+*GitHub Actions* as the source, and each release republishes the distribution.
+
+## Two failure modes worth knowing
+
+Both are silent, which is what makes them expensive.
+
+**A database version at or below the public one is ignored.** `juliaup` replaces its cached
+database only when the number it reads exceeds *both* the number compiled into its own binary and
+its local copy — and it logs nothing when it does not. Your channels simply never appear. Always
+publish above the public number; AppBundler resolves this for you by checking upstream, and the
+bundled workflow additionally seeds the previously published number so republishing keeps climbing.
+
+**All four pointer files must agree.** `juliaup` reads exactly one of them, depending on the channel
+it was itself installed from: `release` clients read `RELEASECHANNELDBVERSION`, `releasepreview`
+clients `RELEASEPREVIEWCHANNELDBVERSION`, `dev` clients `DEVCHANNELDBVERSION`. AppBundler writes all
+four with the same number, so a user on a preview client does not take a 404 on a database your
+mirror never wrote.
+
+## Target triples
+
+A database file is named after the Rust target triple of the **`juliaup` client binary**, not the
+Julia build it installs. There are 13, and AppBundler writes all of them. Two consequences are easy
+to get wrong by hand:
+
+- The Linux `juliaup` is a musl-static binary that also runs on glibc hosts, so a Linux build has to
+  appear in both the `-musl` and `-gnu` databases. The same holds for the Windows `-gnu`/`-msvc`
+  pair. Upstream publishes these as identical files.
+- A database carries every architecture its client can *execute*. A 64 bit client lists 32 bit
+  builds, and an Apple Silicon client lists x86_64 builds so they can run under Rosetta 2.
+
+## Version strings
+
+A version is identified by a string like `1.12.7+myapp-1x2x0.x64.linux.gnu`: the Julia version, then
+build metadata whose components are the build tag, architecture, vendor and operating system.
+
+`juliaup` splits that metadata on `.` and reads the **second** component as the architecture, so a
+build tag containing dots shifts the index and the entry resolves to a nonsense architecture.
+JuliaHub hit this with early Dyad releases — `1.11.8+dyad-2.1.0-rc3.x64.linux.gnu` parses its
+architecture as `1` — and later switched to `dyad-2x1x0-rc3`. AppBundler sanitises the tag for you,
+which is why `myapp-1.2.0` becomes `myapp-1x2x0`.
+
+## Client wrappers
+
+`--wrappers` writes small scripts that set `JULIAUP_SERVER` and, importantly,
+`JULIAUP_DEPOT_PATH`:
+
+```bash
+export JULIAUP_SERVER=https://acme.github.io/myapp
+export JULIAUP_DEPOT_PATH="${HOME}/.julia/juliaup-depots/acme.github.io"
+
+exec juliaup "$@"
+```
+
+The isolated depot keeps your distribution and the user's stock `juliaup` from sharing channels or
+state, so `myapp-juliaup status` and `juliaup status` list different things and neither can disturb
+the other. Users who prefer not to install wrappers can export the same two variables themselves.
+
+## Known limitation
+
+A distribution installed through `juliaup` is launched as `julia`, not through the `bin/<app>`
+launcher the tarball also ships. That launcher is what normally sets `USER_DATA`, and without it
+AppEnv falls back to a temporary depot on Linux, so packages a user adds on top of the distribution
+do not persist between sessions. Setting `USER_DATA` in the environment restores persistence.
+
+## API
+
+```@docs
+AppBundler.Juliaup
+AppBundler.Juliaup.JuliaupDistribution
+AppBundler.Juliaup.publish
+AppBundler.Juliaup.install_wrappers
+AppBundler.Juliaup.VersionDB
+AppBundler.Juliaup.read_versiondb
+AppBundler.Juliaup.write_versiondb
+AppBundler.Juliaup.add_version!
+AppBundler.Juliaup.add_channel!
+AppBundler.Juliaup.next_dbversion
+AppBundler.Juliaup.fetch_versiondb
+AppBundler.Juliaup.fetch_upstream
+AppBundler.Juliaup.full_version_string
+AppBundler.Juliaup.sanitize_build_tag
+AppBundler.Juliaup.platform_suffix
+AppBundler.Juliaup.targets_for
+AppBundler.install_juliaup_workflow
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -21,13 +21,16 @@ Both specs can be staged directly into a directory for inspection before packagi
 
 ## Bundle Formats
 
-A bundle format defines the packaging target. The three supported formats are `DMG` (macOS), `MSIX` (Windows), and `Snap` (Linux). They are instantiated from a project directory:
+A bundle format defines the packaging target. The supported formats are `DMG` (macOS), `MSIX` (Windows), `Snap` (Linux), and `Tarball` (a relocatable archive for any of them). They are instantiated from a project directory:
 
 ```julia
-dmg  = DMG(project; arch = Sys.ARCH, kwargs...)
-msix = MSIX(project; arch = Sys.ARCH, kwargs...)
-snap = Snap(project; arch = Sys.ARCH, kwargs...)
+dmg     = DMG(project; arch = Sys.ARCH, kwargs...)
+msix    = MSIX(project; arch = Sys.ARCH, kwargs...)
+snap    = Snap(project; arch = Sys.ARCH, kwargs...)
+tarball = Tarball(project; os = :linux, arch = Sys.ARCH, kwargs...)
 ```
+
+`Tarball` is the format a `juliaup` distribution is built from; see [Juliaup](@ref) for publishing one.
 
 Each format reads configuration file overrides from the corresponding `project/meta/<format>` directory and carries architecture information that determines the destination platform. Bundle formats can also be staged independently via `stage(format, destination)` to produce the directory structure before compression and signing.
 
@@ -51,6 +54,7 @@ AppBundler.JuliaCBundle
 AppBundler.DMG
 AppBundler.MSIX
 AppBundler.Snap
+AppBundler.Tarball
 ```
 
 ## Functions
@@ -60,5 +64,6 @@ AppBundler.stage(::AppBundler.JuliaImg.JuliaImgBundle, ::String)
 AppBundler.stage(::AppBundler.JuliaC.JuliaCBundle, ::String)
 AppBundler.stage(::AppBundler.MSIX, ::String)
 AppBundler.bundle(::Function, ::AppBundler.DMG, ::String)
+AppBundler.bundle(::Function, ::AppBundler.MSIX, ::String)
 AppBundler.bundle(::AppBundler.JuliaImgBundle, ::AppBundler.DMG, ::String)
 ```

--- a/justfile
+++ b/justfile
@@ -1,0 +1,50 @@
+# Main entry points for AppBundler development.
+# Run `just` to list them.
+
+julia := "julia --startup-file=no"
+
+default:
+    @just --list
+
+# Install the project's dependencies, including the Python `ds_store` module via Conda
+instantiate:
+    {{julia}} --project=. -e 'using Pkg; Pkg.instantiate()'
+    {{julia}} --project=. deps/build.jl
+
+# Run the test suite
+test:
+    {{julia}} --project=. -e 'using Pkg; Pkg.test()'
+
+# Run the juliaup tests alone
+test-juliaup:
+    {{julia}} --project=. test/juliaup.jl
+    {{julia}} --project=. test/tarball.jl
+
+# Run the juliaup end to end test against a real juliaup client over loopback HTTP
+test-juliaup-e2e:
+    {{julia}} --project=. test/juliaup_e2e.jl
+
+# Run the example bundles as well as the test suite
+test-all:
+    JULIA_RUN_EXAMPLES=true JULIA_RUN_JULIAUP_E2E=true {{julia}} --project=. -e 'using Pkg; Pkg.test()'
+
+# Build the documentation, including llms.txt and llms-full.txt
+docs:
+    {{julia}} --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate()'
+    {{julia}} --project=docs docs/make.jl
+
+# Serve the built documentation locally
+docs-serve: docs
+    {{julia}} -e 'using Sockets; run(`python3 -m http.server -d docs/build 8000`)'
+
+# Build a tarball for the current platform from an example app
+tarball app="examples/GtkApp":
+    {{julia}} --project=. -m AppBundler build {{app}} --build-dir=build --target-bundle=tarball --force
+
+# Publish a juliaup site for an example app into ./site
+juliaup app="examples/GtkApp":
+    {{julia}} --project=. -m AppBundler juliaup {{app}} --build-dir=site --no-mirror
+
+# Remove build outputs
+clean:
+    rm -rf build site docs/build

--- a/recipes/juliaup/julia.ps1
+++ b/recipes/juliaup/julia.ps1
@@ -1,0 +1,14 @@
+# Launches julia from the {{APP_NAME}} distribution.
+#
+# Install a channel first with `{{APP_NAME}}-juliaup add {{JULIAUP_CHANNEL}}`.
+
+if (-not (Get-Command julia -ErrorAction SilentlyContinue)) {
+    Write-Error "{{APP_NAME}}-julia: julia is not installed or not on the PATH. Install it using juliaup, see https://github.com/JuliaLang/juliaup"
+    exit 127
+}
+
+$env:JULIAUP_SERVER = "{{{JULIAUP_SERVER}}}"
+$env:JULIAUP_DEPOT_PATH = Join-Path $HOME ".julia\juliaup-depots\{{JULIAUP_DEPOT}}"
+
+& julia @args
+exit $LASTEXITCODE

--- a/recipes/juliaup/julia.sh
+++ b/recipes/juliaup/julia.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Launches julia from the {{APP_NAME}} distribution.
+#
+# Install a channel first with `{{APP_NAME}}-juliaup add {{JULIAUP_CHANNEL}}`.
+
+command -v julia >/dev/null || {
+  echo "{{APP_NAME}}-julia: julia is not installed or not on the PATH. Install it using juliaup, see https://github.com/JuliaLang/juliaup" >&2
+  exit 127
+}
+
+export JULIAUP_SERVER={{{JULIAUP_SERVER}}}
+export JULIAUP_DEPOT_PATH="${HOME}/.julia/juliaup-depots/{{JULIAUP_DEPOT}}"
+
+exec julia "$@"

--- a/recipes/juliaup/juliaup.ps1
+++ b/recipes/juliaup/juliaup.ps1
@@ -1,0 +1,16 @@
+# Wrapper around juliaup for the {{APP_NAME}} distribution.
+#
+# juliaup downloads from whatever host JULIAUP_SERVER points at, so no patched client is
+# needed. The depot is kept separate from the default one so this distribution and a stock
+# Julia installation do not share channels or state.
+
+if (-not (Get-Command juliaup -ErrorAction SilentlyContinue)) {
+    Write-Error "{{APP_NAME}}-juliaup: juliaup is not installed or not on the PATH. See https://github.com/JuliaLang/juliaup"
+    exit 127
+}
+
+$env:JULIAUP_SERVER = "{{{JULIAUP_SERVER}}}"
+$env:JULIAUP_DEPOT_PATH = Join-Path $HOME ".julia\juliaup-depots\{{JULIAUP_DEPOT}}"
+
+& juliaup @args
+exit $LASTEXITCODE

--- a/recipes/juliaup/juliaup.sh
+++ b/recipes/juliaup/juliaup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Wrapper around juliaup for the {{APP_NAME}} distribution.
+#
+# juliaup downloads from whatever host JULIAUP_SERVER points at, so no patched client is
+# needed. The depot is kept separate from ~/.julia/juliaup so this distribution and a stock
+# Julia installation do not share channels or state.
+
+command -v juliaup >/dev/null || {
+  echo "{{APP_NAME}}-juliaup: juliaup is not installed or not on the PATH. See https://github.com/JuliaLang/juliaup" >&2
+  exit 127
+}
+
+export JULIAUP_SERVER={{{JULIAUP_SERVER}}}
+export JULIAUP_DEPOT_PATH="${HOME}/.julia/juliaup-depots/{{JULIAUP_DEPOT}}"
+
+exec juliaup "$@"

--- a/recipes/snap/snap.yaml
+++ b/recipes/snap/snap.yaml
@@ -2,8 +2,8 @@ name: {{APP_NAME}}
 title: {{APP_DISPLAY_NAME}}
 base: core22
 version: '{{APP_VERSION}}'
-summary: {{APP_SUMMARY}} 
-description: {{APP_DESCRIPTION}}
+summary: "{{APP_SUMMARY}}"
+description: "{{APP_DESCRIPTION}}"
 grade: devel
 confinement: classic 
 

--- a/recipes/tarball/install.ps1
+++ b/recipes/tarball/install.ps1
@@ -1,0 +1,54 @@
+<#
+Installer for {{APP_DISPLAY_NAME}} {{APP_VERSION}} (Windows).
+
+Copies this unpacked bundle to %LOCALAPPDATA%\Programs\{{APP_NAME}} and creates
+a Start Menu shortcut. Per-user state (chats, projects, depot cache) lives under
+%LOCALAPPDATA%\{{APP_DISPLAY_NAME}} and is never touched by install/uninstall.
+
+Usage:
+  powershell -ExecutionPolicy Bypass -File install.ps1 [-Prefix DIR] [-Uninstall]
+
+If you'd rather not install, just run bin\{{APP_NAME}}.bat from the unpacked folder.
+#>
+param(
+    [string]$Prefix = (Join-Path $env:LOCALAPPDATA "Programs\{{APP_NAME}}"),
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+$AppName = "{{APP_NAME}}"
+$AppDisplayName = "{{APP_DISPLAY_NAME}}"
+$StartMenu = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs"
+$Shortcut = Join-Path $StartMenu "$AppDisplayName.lnk"
+
+if ($Uninstall) {
+    Write-Host "Removing $AppDisplayName from $Prefix..."
+    if (Test-Path $Shortcut) { Remove-Item $Shortcut -Force }
+    if (Test-Path $Prefix)   { Remove-Item $Prefix -Recurse -Force }
+    Write-Host "Done. (Per-user data was left intact.)"
+    exit 0
+}
+
+$SrcDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ($SrcDir -eq $Prefix) {
+    Write-Error "Refusing to install into the bundle's own directory ($Prefix). Unpack elsewhere or pass -Prefix."
+    exit 1
+}
+
+Write-Host "Installing $AppDisplayName to $Prefix..."
+if (Test-Path $Prefix) { Remove-Item $Prefix -Recurse -Force }
+New-Item -ItemType Directory -Path $Prefix -Force | Out-Null
+Copy-Item -Path (Join-Path $SrcDir "*") -Destination $Prefix -Recurse -Force
+
+$Launcher = Join-Path $Prefix "bin\$AppName.bat"
+New-Item -ItemType Directory -Path $StartMenu -Force | Out-Null
+$WshShell = New-Object -ComObject WScript.Shell
+$lnk = $WshShell.CreateShortcut($Shortcut)
+$lnk.TargetPath = $Launcher
+$lnk.WorkingDirectory = (Join-Path $Prefix "bin")
+$lnk.Save()
+
+Write-Host ""
+Write-Host "$AppDisplayName installed."
+Write-Host "  Run:       Start Menu -> $AppDisplayName  (or $Launcher)"
+Write-Host "  Uninstall: powershell -ExecutionPolicy Bypass -File `"$Prefix\install.ps1`" -Uninstall"

--- a/recipes/tarball/install.sh
+++ b/recipes/tarball/install.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 #
-# Installer for {{APP_DISPLAY_NAME}} {{APP_VERSION}}.
+# Installer for {{APP_DISPLAY_NAME}} {{APP_VERSION}} (Linux and macOS).
 #
-# Copies this unpacked bundle to a prefix (default /opt/{{APP_NAME}}), symlinks
-# the launcher onto PATH, and registers a desktop entry + icon. Per-user state
-# (chats, projects, depot cache) lives under ~/.local/share/{{APP_DISPLAY_NAME}}
-# and is never touched by install/uninstall.
+# Copies this unpacked bundle to a prefix, symlinks the launcher onto PATH, and
+# (Linux only) registers a desktop entry + icon. Per-user state (chats,
+# projects, depot cache) lives under the platform data dir and is never touched
+# by install/uninstall:
+#   Linux:  ~/.local/share/{{APP_DISPLAY_NAME}}
+#   macOS:  ~/Library/Application Support/{{APP_DISPLAY_NAME}}
 
 set -euo pipefail
 
 APP_NAME="{{APP_NAME}}"
 APP_DISPLAY_NAME="{{APP_DISPLAY_NAME}}"
 
-PREFIX="/opt/${APP_NAME}"
+OS="$(uname -s)"
+case "$OS" in
+    Darwin) PREFIX="/usr/local/${APP_NAME}"; IS_MAC=1 ;;
+    *)      PREFIX="/opt/${APP_NAME}";       IS_MAC=0 ;;
+esac
 BIN_DIR="/usr/local/bin"
 DESKTOP_DIR="/usr/share/applications"
 ICON_DIR="/usr/share/icons/hicolor/512x512/apps"
@@ -45,20 +51,28 @@ DESKTOP_FILE="${DESKTOP_DIR}/${APP_NAME}.desktop"
 ICON_FILE="${ICON_DIR}/${APP_NAME}.png"
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo "This installer writes to ${PREFIX}, ${BIN_DIR} and ${DESKTOP_DIR}." >&2
+    echo "This installer writes to ${PREFIX} and ${BIN_DIR}." >&2
     echo "Please re-run with sudo." >&2
     exit 1
 fi
 
 if [ "$DO_UNINSTALL" -eq 1 ]; then
     echo "Removing ${APP_DISPLAY_NAME} from ${PREFIX}..."
-    rm -f "$LAUNCHER" "$DESKTOP_FILE" "$ICON_FILE"
+    rm -f "$LAUNCHER"
+    [ "$IS_MAC" -eq 0 ] && rm -f "$DESKTOP_FILE" "$ICON_FILE"
     rm -rf "$PREFIX"
-    echo "Done. (Per-user data under ~/.local/share/${APP_DISPLAY_NAME} was left intact.)"
+    echo "Done. (Per-user data was left intact.)"
     exit 0
 fi
 
-SRC_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# Resolve this script's own directory portably (no `readlink -f`, absent on macOS).
+SOURCE="$0"
+while [ -h "$SOURCE" ]; do
+    DIR=$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)
+    SOURCE=$(readlink "$SOURCE")
+    case "$SOURCE" in /*) ;; *) SOURCE="$DIR/$SOURCE" ;; esac
+done
+SRC_DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
 if [ "$SRC_DIR" = "$PREFIX" ]; then
     echo "Refusing to install into the bundle's own directory ($PREFIX)." >&2
@@ -76,14 +90,17 @@ mkdir -p "$PREFIX"
 mkdir -p "$BIN_DIR"
 ln -sf "${PREFIX}/bin/${APP_NAME}" "$LAUNCHER"
 
-if [ -f "${PREFIX}/meta/gui/${APP_NAME}.desktop" ]; then
-    mkdir -p "$DESKTOP_DIR"
-    sed -e "s|@EXEC@|${LAUNCHER}|g" -e "s|@ICON@|${ICON_FILE}|g" \
-        "${PREFIX}/meta/gui/${APP_NAME}.desktop" > "$DESKTOP_FILE"
-fi
-if [ -f "${PREFIX}/meta/icon.png" ]; then
-    mkdir -p "$ICON_DIR"
-    cp "${PREFIX}/meta/icon.png" "$ICON_FILE"
+# Desktop entry + icon are a Linux (freedesktop) concept only.
+if [ "$IS_MAC" -eq 0 ]; then
+    if [ -f "${PREFIX}/meta/gui/${APP_NAME}.desktop" ]; then
+        mkdir -p "$DESKTOP_DIR"
+        sed -e "s|@EXEC@|${LAUNCHER}|g" -e "s|@ICON@|${ICON_FILE}|g" \
+            "${PREFIX}/meta/gui/${APP_NAME}.desktop" > "$DESKTOP_FILE"
+    fi
+    if [ -f "${PREFIX}/meta/icon.png" ]; then
+        mkdir -p "$ICON_DIR"
+        cp "${PREFIX}/meta/icon.png" "$ICON_FILE"
+    fi
 fi
 
 cat <<EOF

--- a/recipes/tarball/install.sh
+++ b/recipes/tarball/install.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Installer for {{APP_DISPLAY_NAME}} {{APP_VERSION}}.
+#
+# Copies this unpacked bundle to a prefix (default /opt/{{APP_NAME}}), symlinks
+# the launcher onto PATH, and registers a desktop entry + icon. Per-user state
+# (chats, projects, depot cache) lives under ~/.local/share/{{APP_DISPLAY_NAME}}
+# and is never touched by install/uninstall.
+
+set -euo pipefail
+
+APP_NAME="{{APP_NAME}}"
+APP_DISPLAY_NAME="{{APP_DISPLAY_NAME}}"
+
+PREFIX="/opt/${APP_NAME}"
+BIN_DIR="/usr/local/bin"
+DESKTOP_DIR="/usr/share/applications"
+ICON_DIR="/usr/share/icons/hicolor/512x512/apps"
+DO_UNINSTALL=0
+
+usage() {
+    cat <<EOF
+Install ${APP_DISPLAY_NAME} ${APP_VERSION:-}.
+
+Usage: sudo ./install.sh [--prefix DIR] [--uninstall]
+
+  --prefix DIR   install location (default: ${PREFIX})
+  --uninstall    remove a previous installation at --prefix
+  -h, --help     show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --prefix) PREFIX="$2"; shift 2 ;;
+        --prefix=*) PREFIX="${1#*=}"; shift ;;
+        --uninstall) DO_UNINSTALL=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown argument: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+LAUNCHER="${BIN_DIR}/${APP_NAME}"
+DESKTOP_FILE="${DESKTOP_DIR}/${APP_NAME}.desktop"
+ICON_FILE="${ICON_DIR}/${APP_NAME}.png"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This installer writes to ${PREFIX}, ${BIN_DIR} and ${DESKTOP_DIR}." >&2
+    echo "Please re-run with sudo." >&2
+    exit 1
+fi
+
+if [ "$DO_UNINSTALL" -eq 1 ]; then
+    echo "Removing ${APP_DISPLAY_NAME} from ${PREFIX}..."
+    rm -f "$LAUNCHER" "$DESKTOP_FILE" "$ICON_FILE"
+    rm -rf "$PREFIX"
+    echo "Done. (Per-user data under ~/.local/share/${APP_DISPLAY_NAME} was left intact.)"
+    exit 0
+fi
+
+SRC_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+
+if [ "$SRC_DIR" = "$PREFIX" ]; then
+    echo "Refusing to install into the bundle's own directory ($PREFIX)." >&2
+    echo "Unpack elsewhere or choose a different --prefix." >&2
+    exit 1
+fi
+
+echo "Installing ${APP_DISPLAY_NAME} to ${PREFIX}..."
+rm -rf "$PREFIX"
+mkdir -p "$PREFIX"
+# Stream-copy the whole tree (preserves symlinks, perms and the executable bits
+# on bin/julia, the launcher and this script).
+( cd "$SRC_DIR" && tar -cf - . ) | ( cd "$PREFIX" && tar -xf - )
+
+mkdir -p "$BIN_DIR"
+ln -sf "${PREFIX}/bin/${APP_NAME}" "$LAUNCHER"
+
+if [ -f "${PREFIX}/meta/gui/${APP_NAME}.desktop" ]; then
+    mkdir -p "$DESKTOP_DIR"
+    sed -e "s|@EXEC@|${LAUNCHER}|g" -e "s|@ICON@|${ICON_FILE}|g" \
+        "${PREFIX}/meta/gui/${APP_NAME}.desktop" > "$DESKTOP_FILE"
+fi
+if [ -f "${PREFIX}/meta/icon.png" ]; then
+    mkdir -p "$ICON_DIR"
+    cp "${PREFIX}/meta/icon.png" "$ICON_FILE"
+fi
+
+cat <<EOF
+
+${APP_DISPLAY_NAME} installed.
+  Run:       ${APP_NAME}        (or ${LAUNCHER})
+  Uninstall: sudo ${PREFIX}/install.sh --uninstall
+EOF

--- a/recipes/tarball/juliaimg_main.bat
+++ b/recipes/tarball/juliaimg_main.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal enableextensions
+
+rem Launcher for {{APP_DISPLAY_NAME}} on Windows. Sits in bin\ next to the
+rem bundle's own julia.exe; %~dp0 is this script's directory (trailing slash).
+set "SCRIPT_DIR=%~dp0"
+set "JULIA=%SCRIPT_DIR%julia.exe"
+
+rem Persist app state under %LOCALAPPDATA% unless already set. AppEnv reads
+rem USER_DATA in startup.jl to place the Julia depot cache there.
+if "%USER_DATA%"=="" set "USER_DATA=%LOCALAPPDATA%\{{APP_DISPLAY_NAME}}"
+
+"%JULIA%" {{#MODULE_NAME}}--eval="using {{MODULE_NAME}}" -- {{/MODULE_NAME}}%*

--- a/recipes/tarball/juliaimg_main.sh
+++ b/recipes/tarball/juliaimg_main.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Resolve the real bundle directory even when invoked through a PATH symlink
+# (e.g. /usr/local/bin/{{APP_NAME}} -> /opt/{{APP_NAME}}/bin/{{APP_NAME}}):
+# readlink -f follows the link so JULIA points at the bundle's own julia.
+SCRIPT_DIR=$(cd "$(dirname "$(readlink -f "$0")")" && pwd)
+JULIA="$SCRIPT_DIR/julia"
+
+# Persist app state under an XDG-conventional directory unless already set.
+# AppEnv reads USER_DATA in startup.jl to place the Julia depot cache there.
+if [ -z "${USER_DATA}" ]; then
+    export USER_DATA="${XDG_DATA_HOME:-${HOME}/.local/share}/{{APP_DISPLAY_NAME}}"
+fi
+
+exec "$JULIA" {{#MODULE_NAME}}--eval="using {{MODULE_NAME}}" -- {{/MODULE_NAME}}"$@"

--- a/recipes/tarball/juliaimg_main.sh
+++ b/recipes/tarball/juliaimg_main.sh
@@ -1,15 +1,25 @@
 #!/bin/bash
 
 # Resolve the real bundle directory even when invoked through a PATH symlink
-# (e.g. /usr/local/bin/{{APP_NAME}} -> /opt/{{APP_NAME}}/bin/{{APP_NAME}}):
-# readlink -f follows the link so JULIA points at the bundle's own julia.
-SCRIPT_DIR=$(cd "$(dirname "$(readlink -f "$0")")" && pwd)
+# (e.g. /usr/local/bin/{{APP_NAME}} -> /opt/{{APP_NAME}}/bin/{{APP_NAME}}).
+# Done portably (no `readlink -f`, which BSD/macOS lacks) so this one launcher
+# serves both Linux and macOS.
+SOURCE="$0"
+while [ -h "$SOURCE" ]; do
+    DIR=$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)
+    SOURCE=$(readlink "$SOURCE")
+    case "$SOURCE" in /*) ;; *) SOURCE="$DIR/$SOURCE" ;; esac
+done
+SCRIPT_DIR=$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)
 JULIA="$SCRIPT_DIR/julia"
 
-# Persist app state under an XDG-conventional directory unless already set.
+# Persist app state under a platform-conventional directory unless already set.
 # AppEnv reads USER_DATA in startup.jl to place the Julia depot cache there.
 if [ -z "${USER_DATA}" ]; then
-    export USER_DATA="${XDG_DATA_HOME:-${HOME}/.local/share}/{{APP_DISPLAY_NAME}}"
+    case "$(uname -s)" in
+        Darwin) export USER_DATA="${HOME}/Library/Application Support/{{APP_DISPLAY_NAME}}" ;;
+        *)      export USER_DATA="${XDG_DATA_HOME:-${HOME}/.local/share}/{{APP_DISPLAY_NAME}}" ;;
+    esac
 fi
 
 exec "$JULIA" {{#MODULE_NAME}}--eval="using {{MODULE_NAME}}" -- {{/MODULE_NAME}}"$@"

--- a/recipes/tarball/main.desktop
+++ b/recipes/tarball/main.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name={{APP_DISPLAY_NAME}}
+Exec=@EXEC@
+Icon=@ICON@
+Version={{APP_VERSION}}
+Comment={{APP_SUMMARY}}
+Terminal={{#WINDOWED}}false{{/WINDOWED}}{{^WINDOWED}}true{{/WINDOWED}}
+Type=Application
+Categories=Utility;

--- a/recipes/workflows/JuliaupPages.yml
+++ b/recipes/workflows/JuliaupPages.yml
@@ -1,0 +1,144 @@
+name: Publish Juliaup Distribution
+
+# Builds a relocatable tarball for every platform, attaches them to the release, and publishes
+# the juliaup version database to GitHub Pages. Users then install the distribution with:
+#
+#   export JULIAUP_SERVER=https://<owner>.github.io/<repo>
+#   juliaup add <channel>
+#
+# The database only names *paths*, so the tarballs stay on the releases page and none of their
+# bytes ever pass through Pages.
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload_tag:
+        description: 'Release tag to publish'
+        required: false
+        default: ''
+        type: string
+  release:
+    types: [created]
+
+# Required for `actions/deploy-pages`.
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# A half-published database is worse than a stale one, so never run two of these at once.
+concurrency:
+  group: juliaup-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            os: linux
+            arch: x86_64
+          - runner: ubuntu-24.04-arm
+            os: linux
+            arch: aarch64
+          - runner: macos-13
+            os: macos
+            arch: x86_64
+          - runner: macos-latest
+            os: macos
+            arch: aarch64
+          - runner: windows-latest
+            os: windows
+            arch: x86_64
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+      - uses: julia-actions/cache@v2
+
+      - name: Install dependencies
+        run: julia --project=meta -e 'using Pkg; Pkg.instantiate()'
+
+      # Julia does not cross-compile, so each tarball is built on a matching runner.
+      - name: Build tarball
+        run: >
+          julia --project=meta -m AppBundler build .
+          --build-dir=build
+          --target-bundle=tarball
+          --target-os=${{ matrix.os }}
+          --target-arch=${{ matrix.arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: tarball-${{ matrix.os }}-${{ matrix.arch }}
+          path: build/*.tar.gz
+          retention-days: 1
+
+  publish:
+    name: Publish database to Pages
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release' || github.event.inputs.upload_tag != ''
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.12'
+
+      - name: Install dependencies
+        run: julia --project=meta -e 'using Pkg; Pkg.instantiate()'
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Attach tarballs to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG_NAME="${{ github.event.inputs.upload_tag || github.event.release.tag_name }}"
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          find artifacts/ -name '*.tar.gz' -type f -print0 |
+            xargs -0 -I{} gh release upload "$TAG_NAME" {} --clobber
+
+      # juliaup only replaces its cached database when the published number is greater than
+      # both the number built into its binary and its local copy — and it reports nothing when
+      # it is not. Seeding the site with what is already live lets AppBundler keep climbing
+      # instead of republishing a number clients have already cached.
+      - name: Seed the previously published database version
+        continue-on-error: true
+        run: |
+          mkdir -p site/juliaup
+          curl -fsSL "${{ steps.pages.outputs.base_url || format('https://{0}.github.io/{1}', github.repository_owner, github.event.repository.name) }}/juliaup/RELEASECHANNELDBVERSION" \
+            -o site/juliaup/RELEASECHANNELDBVERSION || true
+
+      - name: Build the juliaup database
+        run: >
+          julia --project=meta -m AppBundler juliaup .
+          --build-dir=site
+          --server=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          --asset-base=https://github.com/${{ github.repository }}/releases/download/${{ env.TAG_NAME }}
+          --platform=linux/x86_64
+          --platform=linux/aarch64
+          --platform=macos/x86_64
+          --platform=macos/aarch64
+          --platform=windows/x86_64
+          --wrappers
+
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deploy
+        uses: actions/deploy-pages@v4

--- a/src/AppBundler.jl
+++ b/src/AppBundler.jl
@@ -29,6 +29,8 @@ include("DMG/DMGPack.jl")
 
 include("Snap/SnapPack.jl")
 
+include("Tarball/TarPack.jl")
+
 include("MSIX/MSIXPack.jl")
 include("MSIX/MSIXIcons.jl")
 include("MSIX/WinSubsystem.jl")
@@ -64,7 +66,7 @@ end
 #@doc (@doc JuliaImg.JuliaImgBundle) JuliaImgBundle
 #@doc (@doc JuliaC.JuliaCBundle) JuliaCBundle
 
-export JuliaImgBundle, JuliaCBundle, DMG, MSIX, Snap, bundle, stage
+export JuliaImgBundle, JuliaCBundle, DMG, MSIX, Snap, Tarball, bundle, stage
 export main 
 
 

--- a/src/AppBundler.jl
+++ b/src/AppBundler.jl
@@ -42,6 +42,8 @@ include("bundlers/JuliaC.jl")
 using .JuliaImg: install
 using .JuliaImg.Resources: merge_directories#, install
 
+include("Juliaup/Juliaup.jl")
+
 include("utils.jl")
 include("bundle.jl")
 include("recipes.jl") 

--- a/src/Juliaup/Distribution.jl
+++ b/src/Juliaup/Distribution.jl
@@ -1,0 +1,337 @@
+"""
+    JuliaupDistribution([overlay]; channel, julia_version, build_tag, kwargs...)
+
+Description of a Julia distribution published through `juliaup`.
+
+Users install it by pointing `JULIAUP_SERVER` at `server` and running `juliaup add <channel>`.
+The wrappers produced by [`install_wrappers`](@ref) set that variable for them and isolate the
+depot so a stock `juliaup` installation is left untouched.
+
+When `overlay` is provided, application parameters (`APP_NAME`, `APP_VERSION`, ...) are read from
+`overlay/Project.toml` and defaults from `overlay/LocalPreferences.toml`, exactly as for the
+[`DMG`](@ref), [`MSIX`](@ref) and [`Snap`](@ref) formats.
+
+# Keyword Arguments
+- `channel`: Channel name users pass to `juliaup add`, e.g. `"myapp-1.2.0"`
+- `julia_version`: Julia version the distribution is built on, taken from the bundled runtime
+- `build_tag`: Build identifier embedded in the full version string; sanitized with
+  [`sanitize_build_tag`](@ref)
+- `server`: HTTPS base url the database is published under, used by the client wrappers
+- `asset_base`: Base path or url the tarballs are served from. A relative value keeps the database
+  portable across hosts, an absolute url points at another host such as GitHub releases
+- `mirror = true`: Merge the upstream database in so the stock channels keep working
+- `dbversion = nothing`: Database version to publish; resolved above upstream at publish time when
+  left unset
+- `depot`: Directory under `~/.julia/juliaup-depots` the wrappers isolate the installation into;
+  defaults to the server host
+- `upstream_server = DEFAULT_SERVER`: Server to mirror from
+"""
+struct JuliaupDistribution
+    channel::String
+    julia_version::VersionNumber
+    build_tag::String
+    server::String
+    asset_base::String
+    mirror::Bool
+    dbversion::Union{VersionNumber, Nothing}
+    depot::String
+    upstream_server::String
+    parameters::Dict{String, Any}
+end
+
+function JuliaupDistribution(;
+                             channel::AbstractString,
+                             julia_version::VersionNumber,
+                             build_tag::AbstractString,
+                             app_name::AbstractString,
+                             app_version::AbstractString,
+                             server::AbstractString = "",
+                             asset_base::AbstractString = "assets",
+                             mirror::Bool = true,
+                             dbversion::Union{VersionNumber, Nothing} = nothing,
+                             depot::AbstractString = default_depot(server),
+                             upstream_server::AbstractString = DEFAULT_SERVER,
+                             parameters::Dict{String, Any} = Dict{String, Any}())
+
+    validate_server(server)
+    sanitize_build_tag(build_tag) # fail here rather than on every user's machine
+
+    parameters = copy(parameters)
+    parameters["APP_NAME"] = app_name
+    parameters["APP_VERSION"] = app_version
+    parameters["JULIAUP_CHANNEL"] = channel
+    parameters["JULIAUP_SERVER"] = server
+    parameters["JULIAUP_DEPOT"] = depot
+
+    return JuliaupDistribution(channel, julia_version, build_tag, server, asset_base,
+                               mirror, dbversion, depot, upstream_server, parameters)
+end
+
+function JuliaupDistribution(overlay::AbstractString; preferences = AppBundler.preferences(), kwargs...)
+
+    parameters = AppBundler.get_bundle_parameters!(Dict{String, Any}(),
+                                                   joinpath(overlay, "Project.toml"); preferences)
+
+    app_name = parameters["APP_NAME"]
+    app_version = parameters["APP_VERSION"]
+
+    defaults = (channel = get(preferences, "juliaup_channel", "$app_name-$app_version"),
+                julia_version = JuliaImg.get_julia_version(overlay),
+                build_tag = "$app_name-$app_version",
+                server = get(preferences, "juliaup_server", ""),
+                asset_base = get(preferences, "juliaup_asset_base", "assets"),
+                mirror = get(preferences, "juliaup_mirror", true),
+                upstream_server = get(preferences, "juliaup_upstream_server", DEFAULT_SERVER))
+
+    return JuliaupDistribution(; defaults..., app_name, app_version, parameters, kwargs...)
+end
+
+"""
+    validate_server(server::AbstractString)
+
+Reject a server url `juliaup` would refuse. It requires HTTPS except on loopback, and rather than
+let every user discover that, fail while publishing.
+"""
+function validate_server(server::AbstractString)
+
+    isempty(server) && return
+
+    scheme, rest = if startswith(server, "https://")
+        ("https", server[9:end])
+    elseif startswith(server, "http://")
+        ("http", server[8:end])
+    else
+        error("The juliaup server `$server` must be an http(s) url")
+    end
+
+    host = first(split(first(split(rest, '/')), ':'))
+
+    if scheme == "http" && !(host in ["localhost", "127.0.0.1", "::1", "[::1]"])
+        error("juliaup refuses a plain HTTP server unless it is loopback. Publish `$server` " *
+              "over HTTPS instead.")
+    end
+
+    return
+end
+
+"""
+    default_depot(server::AbstractString) -> String
+
+Directory name under `~/.julia/juliaup-depots` to isolate a distribution into, derived from the
+server host so distributions from different vendors do not collide.
+"""
+function default_depot(server::AbstractString)
+
+    isempty(server) && return "appbundler"
+
+    rest = replace(server, r"^https?://" => "")
+    host = first(split(first(split(rest, '/')), ':'))
+
+    return isempty(host) ? "appbundler" : String(host)
+end
+
+"""
+    target_platform(target::AbstractString) -> Tuple{Symbol, Symbol}
+
+Return the `(os, arch)` a `juliaup` client with this target triple runs natively.
+"""
+function target_platform(target::AbstractString)
+
+    arch = startswith(target, "x86_64") ? :x86_64 :
+           startswith(target, "i686") ? :i686 :
+           startswith(target, "aarch64") ? :aarch64 :
+           error("Can not determine the architecture of juliaup target `$target`")
+
+    os = occursin("linux", target) ? :linux :
+         occursin("darwin", target) ? :macos :
+         occursin("windows", target) ? :windows :
+         occursin("freebsd", target) ? :freebsd :
+         error("Can not determine the operating system of juliaup target `$target`")
+
+    return (os, arch)
+end
+
+"""
+    asset_url(dist::JuliaupDistribution, os::Symbol, arch::Symbol) -> String
+
+Url of the tarball for one platform, following the naming the tarball bundle target produces:
+`<app-name>-<app-version>-<os>-<arch>.tar.gz`.
+"""
+function asset_url(dist::JuliaupDistribution, os::Symbol, arch::Symbol)
+
+    name = "$(dist.parameters["APP_NAME"])-$(dist.parameters["APP_VERSION"])-$os-$arch.tar.gz"
+
+    return isempty(dist.asset_base) ? name : rstrip(dist.asset_base, '/') * "/" * name
+end
+
+"""
+    publish(dist::JuliaupDistribution, site::String; assets, upstream = nothing, dbversion = nothing)
+
+Write the static file tree a `juliaup` client reads into `site`.
+
+`assets` lists the platforms that were built, either as `(os, arch)` tuples — whose tarball urls are
+then derived from `dist.asset_base` — or as `(os, arch) => url` pairs when the urls are known.
+
+The resulting tree can be served by any static host:
+
+```
+<site>/juliaup/DBVERSION
+<site>/juliaup/RELEASECHANNELDBVERSION
+<site>/juliaup/RELEASEPREVIEWCHANNELDBVERSION
+<site>/juliaup/DEVCHANNELDBVERSION
+<site>/juliaup/versiondb/versiondb-<dbversion>-<target>.json   (one per target triple)
+```
+
+All four pointer files carry the same number. `juliaup` reads only the one matching the channel it
+was installed from, and a client on `dev` or `releasepreview` would otherwise take a 404 on a
+database that was never written.
+"""
+function publish(dist::JuliaupDistribution, site::String;
+                 assets,
+                 upstream::Union{Dict{String, VersionDB}, Nothing} = nothing,
+                 dbversion::Union{VersionNumber, Nothing} = dist.dbversion)
+
+    platforms = normalize_assets(dist, assets)
+
+    isempty(platforms) && error("No assets were given to publish. Pass at least one (os, arch).")
+
+    if isnothing(upstream) && dist.mirror
+        upstream = fetch_upstream(; server = dist.upstream_server)
+    end
+
+    if isnothing(dbversion)
+        upstream_version = isnothing(upstream) ? fetch_dbversion(; server = dist.upstream_server) :
+            maximum(db.dbversion for db in values(upstream))
+        dbversion = next_dbversion(upstream_version, published_dbversion(site, upstream_version))
+    end
+
+    juliaup_dir = joinpath(site, "juliaup")
+    mkpath(joinpath(juliaup_dir, "versiondb"))
+
+    for target in JULIAUP_TARGETS
+
+        base = isnothing(upstream) ? VersionDB(dbversion) : copy(upstream[target])
+        db = VersionDB(base.versions, base.channels, dbversion)
+
+        register!(db, dist, target, platforms)
+
+        write_versiondb(joinpath(juliaup_dir, "versiondb", "versiondb-$dbversion-$target.json"), db)
+    end
+
+    for name in DBVERSION_FILES
+        write(joinpath(juliaup_dir, name), "$dbversion\n")
+    end
+
+    @info "Published juliaup channel `$(dist.channel)` at database version $dbversion into $site"
+
+    return dbversion
+end
+
+function normalize_assets(dist::JuliaupDistribution, assets)
+
+    platforms = Pair{Tuple{Symbol, Symbol}, String}[]
+
+    for entry in assets
+        if entry isa Pair
+            os, arch = entry.first
+            push!(platforms, (os, arch) => String(entry.second))
+        else
+            os, arch = entry
+            push!(platforms, (os, arch) => asset_url(dist, os, arch))
+        end
+    end
+
+    return platforms
+end
+
+"""
+    register!(db, dist, target, platforms)
+
+Add the distribution's versions and channels to one target's database.
+
+Every platform the target can execute is registered under a `<channel>~<arch>` alias, following the
+convention upstream uses. The bare channel resolves to the target's native architecture when it was
+built, and otherwise to the first compatible build — which is how an Apple Silicon client falls back
+to an x86_64 distribution through Rosetta 2.
+"""
+function register!(db::VersionDB, dist::JuliaupDistribution, target::AbstractString, platforms)
+
+    compatible = [platform for platform in platforms if target in targets_for(platform.first...)]
+
+    isempty(compatible) && return db
+
+    native = target_platform(target)
+    preferred = something(findfirst(platform -> platform.first == native, compatible), 1)
+
+    for (index, ((os, arch), url)) in enumerate(compatible)
+
+        fullversion = full_version_string(dist.julia_version, dist.build_tag, os, arch)
+
+        add_version!(db, fullversion, url)
+        add_channel!(db, "$(dist.channel)~$(juliaup_arch(os, arch))", fullversion)
+
+        if index == preferred
+            add_channel!(db, dist.channel, fullversion)
+        end
+    end
+
+    return db
+end
+
+"""
+    juliaup_arch(os::Symbol, arch::Symbol) -> String
+
+Architecture token `juliaup` uses in channel aliases and version strings: `x64`, `x86` or `aarch64`.
+"""
+juliaup_arch(os::Symbol, arch::Symbol) = String(first(split(platform_suffix(os, arch), '.')))
+
+"""
+    published_dbversion(site::String, fallback::VersionNumber) -> VersionNumber
+
+Read back the database version a site already advertises, so republishing keeps climbing rather
+than reusing a number clients have already cached.
+"""
+function published_dbversion(site::String, fallback::VersionNumber)
+
+    path = joinpath(site, "juliaup", "RELEASECHANNELDBVERSION")
+
+    isfile(path) || return fallback
+
+    return try
+        VersionNumber(strip(read(path, String)))
+    catch
+        fallback
+    end
+end
+
+"""
+    install_wrappers(dist::JuliaupDistribution, destination::String)
+
+Write the client wrappers into `destination`: `<app>-juliaup` and `<app>-julia`, plus PowerShell
+equivalents for Windows.
+
+They export `JULIAUP_SERVER` and `JULIAUP_DEPOT_PATH` before delegating to the real binaries, so a
+user's stock `juliaup` installation and its channels are left alone. This mirrors how the Dyad
+distribution is shipped.
+"""
+function install_wrappers(dist::JuliaupDistribution, destination::String;
+                          prefix = joinpath(dirname(dirname(@__DIR__)), "recipes"))
+
+    isempty(dist.server) && error("A juliaup `server` must be configured before client wrappers " *
+                                  "can be written, otherwise they point nowhere.")
+
+    mkpath(destination)
+
+    app_name = dist.parameters["APP_NAME"]
+
+    for (source, target, executable) in [("juliaup/juliaup.sh", "$app_name-juliaup", true),
+                                         ("juliaup/julia.sh", "$app_name-julia", true),
+                                         ("juliaup/juliaup.ps1", "$app_name-juliaup.ps1", false),
+                                         ("juliaup/julia.ps1", "$app_name-julia.ps1", false)]
+
+        AppBundler.install(joinpath(prefix, source), joinpath(destination, target);
+                           parameters = dist.parameters, executable, force = true)
+    end
+
+    return
+end

--- a/src/Juliaup/Juliaup.jl
+++ b/src/Juliaup/Juliaup.jl
@@ -1,0 +1,23 @@
+"""
+    Juliaup
+
+Publishing of AppBundler-produced distributions through `juliaup`.
+
+`juliaup` downloads from whatever host `JULIAUP_SERVER` points at, so distributing a bundled Julia
+through it needs no fork and no dedicated infrastructure — only a handful of static files. This
+module writes them: the per-target version databases and the `*DBVERSION` pointer files that tell a
+client which database to fetch.
+
+See the [Juliaup](@ref) section of the documentation for the full workflow.
+"""
+module Juliaup
+
+using ..AppBundler
+using ..AppBundler: JuliaImg
+
+include("VersionDB.jl")
+include("Distribution.jl")
+
+export JuliaupDistribution, publish, install_wrappers
+
+end

--- a/src/Juliaup/VersionDB.jl
+++ b/src/Juliaup/VersionDB.jl
@@ -1,0 +1,320 @@
+import JSON
+import Downloads
+
+"""
+Rust target triples for which `juliaup` publishes a version database.
+
+The triple identifies the *`juliaup` client binary*, not the Julia build it installs. Each client
+downloads `versiondb-<dbversion>-<target>.json` and nothing else, so a distribution must be
+written into every target a prospective user might run. Notably the Linux client is a
+musl-static binary that also runs on glibc hosts, which is why both variants exist and carry
+identical content upstream.
+"""
+const JULIAUP_TARGETS = ["aarch64-apple-darwin",
+                         "aarch64-unknown-linux-gnu",
+                         "aarch64-unknown-linux-musl",
+                         "i686-pc-windows-gnu",
+                         "i686-pc-windows-msvc",
+                         "i686-unknown-linux-gnu",
+                         "i686-unknown-linux-musl",
+                         "x86_64-apple-darwin",
+                         "x86_64-pc-windows-gnu",
+                         "x86_64-pc-windows-msvc",
+                         "x86_64-unknown-freebsd",
+                         "x86_64-unknown-linux-gnu",
+                         "x86_64-unknown-linux-musl"]
+
+"""
+Pointer files naming the database version currently published.
+
+`juliaup` reads exactly one of these depending on the channel it was itself installed from
+(`release`, `releasepreview` or `dev`), so all of them must be written and must agree. Upstream
+carries no `DEVPREVIEWCHANNELDBVERSION`, and a client whose pointer file is missing fails with a
+404 on a database the mirror never wrote.
+"""
+const DBVERSION_FILES = ["DBVERSION",
+                         "RELEASECHANNELDBVERSION",
+                         "RELEASEPREVIEWCHANNELDBVERSION",
+                         "DEVCHANNELDBVERSION"]
+
+"""
+Default server `juliaup` downloads from when `JULIAUP_SERVER` is unset.
+"""
+const DEFAULT_SERVER = "https://julialang-s3.julialang.org"
+
+# Architecture as `juliaup` spells it in a full version string, keyed by (os, arch).
+const PLATFORM_SUFFIXES = Dict((:linux, :x86_64) => "x64.linux.gnu",
+                               (:linux, :i686) => "x86.linux.gnu",
+                               (:linux, :aarch64) => "aarch64.linux.gnu",
+                               (:macos, :x86_64) => "x64.apple.darwin14",
+                               (:macos, :aarch64) => "aarch64.apple.darwin14",
+                               (:windows, :x86_64) => "x64.w64.mingw32",
+                               (:windows, :i686) => "x86.w64.mingw32",
+                               (:freebsd, :x86_64) => "x64.unknown.freebsd11.1")
+
+# Which client databases a build must be written into. A client lists every architecture it can
+# execute, mirroring `compatible_archs` in juliaup: 64 bit hosts run 32 bit builds, and Apple
+# Silicon runs x86_64 builds through Rosetta 2.
+const TARGET_MAP = Dict((:linux, :x86_64) => ["x86_64-unknown-linux-gnu",
+                                              "x86_64-unknown-linux-musl"],
+                        (:linux, :i686) => ["i686-unknown-linux-gnu",
+                                            "i686-unknown-linux-musl",
+                                            "x86_64-unknown-linux-gnu",
+                                            "x86_64-unknown-linux-musl"],
+                        (:linux, :aarch64) => ["aarch64-unknown-linux-gnu",
+                                               "aarch64-unknown-linux-musl"],
+                        (:macos, :x86_64) => ["x86_64-apple-darwin",
+                                              "aarch64-apple-darwin"],
+                        (:macos, :aarch64) => ["aarch64-apple-darwin"],
+                        (:windows, :x86_64) => ["x86_64-pc-windows-gnu",
+                                                "x86_64-pc-windows-msvc"],
+                        (:windows, :i686) => ["i686-pc-windows-gnu",
+                                              "i686-pc-windows-msvc",
+                                              "x86_64-pc-windows-gnu",
+                                              "x86_64-pc-windows-msvc"],
+                        (:freebsd, :x86_64) => ["x86_64-unknown-freebsd"])
+
+"""
+    VersionDB(versions, channels, dbversion)
+
+In-memory form of a `juliaup` version database.
+
+- `versions` maps a full version string such as `"1.12.7+0.x64.linux.gnu"` to the `UrlPath` of the
+  distribution tarball. The path is resolved against the server base, so a relative value keeps the
+  database portable across hosts while an absolute URL points at another host entirely.
+- `channels` maps a channel name such as `"release"` to a key of `versions`.
+- `dbversion` is the number published in the `*DBVERSION` pointer files.
+"""
+struct VersionDB
+    versions::Dict{String, String}
+    channels::Dict{String, String}
+    dbversion::VersionNumber
+end
+
+VersionDB(dbversion::VersionNumber) = VersionDB(Dict{String, String}(), Dict{String, String}(), dbversion)
+
+Base.copy(db::VersionDB) = VersionDB(copy(db.versions), copy(db.channels), db.dbversion)
+
+"""
+    platform_suffix(os::Symbol, arch::Symbol) -> String
+
+Return the `<arch>.<vendor>.<os>` tail `juliaup` expects in a full version string.
+"""
+function platform_suffix(os::Symbol, arch::Symbol)
+
+    suffix = get(PLATFORM_SUFFIXES, (os, arch), nothing)
+
+    if isnothing(suffix)
+        error("No juliaup platform is defined for $os/$arch. Supported combinations are: " *
+              join(("$o/$a" for (o, a) in sort(collect(keys(PLATFORM_SUFFIXES)))), ", "))
+    end
+
+    return suffix
+end
+
+"""
+    targets_for(os::Symbol, arch::Symbol) -> Vector{String}
+
+Return the client databases a build for `os`/`arch` must be written into.
+"""
+function targets_for(os::Symbol, arch::Symbol)
+
+    targets = get(TARGET_MAP, (os, arch), nothing)
+
+    if isnothing(targets)
+        error("No juliaup targets are defined for $os/$arch. Supported combinations are: " *
+              join(("$o/$a" for (o, a) in sort(collect(keys(TARGET_MAP)))), ", "))
+    end
+
+    return copy(targets)
+end
+
+"""
+    sanitize_build_tag(tag::AbstractString) -> String
+
+Replace `.` with `x` in a build tag so it survives `juliaup`'s parsing.
+
+`juliaup` splits the build metadata of a full version string on `.` and reads the second component
+as the architecture. A tag carrying dots shifts that index, and the entry silently resolves to a
+nonsense architecture. JuliaHub hit this with early Dyad releases — `1.11.8+dyad-2.1.0-rc3.x64.linux.gnu`
+parses its architecture as `"1"` — and their later entries read `dyad-2x1x0-rc3` instead.
+"""
+function sanitize_build_tag(tag::AbstractString)
+
+    isempty(tag) && error("The build tag must not be empty")
+
+    sanitized = replace(tag, '.' => 'x')
+
+    if !occursin(r"^[A-Za-z0-9\-]+$", sanitized)
+        error("The build tag `$tag` is not a valid semantic version build identifier. Only " *
+              "alphanumeric characters, `-` and `.` are allowed.")
+    end
+
+    return sanitized
+end
+
+"""
+    full_version_string(julia_version, build_tag, os, arch) -> String
+
+Build the key `juliaup` uses to identify an installable version, for instance
+`"1.12.7+myapp-1x2x0.x64.linux.gnu"`. The build tag is sanitized with [`sanitize_build_tag`](@ref).
+"""
+function full_version_string(julia_version::VersionNumber, build_tag::AbstractString, os::Symbol, arch::Symbol)
+
+    version = VersionNumber(julia_version.major, julia_version.minor, julia_version.patch)
+
+    return "$version+$(sanitize_build_tag(build_tag)).$(platform_suffix(os, arch))"
+end
+
+"""
+    read_versiondb(path::String) -> VersionDB
+
+Parse a `juliaup` version database. The nested JSON objects are flattened into plain `Dict`s so
+the representation does not depend on the JSON implementation.
+"""
+function read_versiondb(path::String)
+
+    parsed = JSON.parsefile(path)
+
+    versions = Dict{String, String}(key => value["UrlPath"]
+                                    for (key, value) in parsed["AvailableVersions"])
+
+    channels = Dict{String, String}(key => value["Version"]
+                                    for (key, value) in parsed["AvailableChannels"])
+
+    return VersionDB(versions, channels, VersionNumber(parsed["Version"]))
+end
+
+"""
+    write_versiondb(path::String, db::VersionDB)
+
+Serialize `db` into the shape `juliaup` deserializes. Keys are sorted so republishing an unchanged
+database produces an unchanged file.
+"""
+function write_versiondb(path::String, db::VersionDB)
+
+    mkpath(dirname(path))
+
+    document = Dict("AvailableVersions" => Dict(key => Dict("UrlPath" => db.versions[key])
+                                                for key in sort(collect(keys(db.versions)))),
+                    "AvailableChannels" => Dict(key => Dict("Version" => db.channels[key])
+                                                for key in sort(collect(keys(db.channels)))),
+                    "Version" => string(db.dbversion))
+
+    open(path, "w") do file
+        write(file, JSON.json(document))
+    end
+
+    return
+end
+
+"""
+    add_version!(db::VersionDB, fullversion::String, urlpath::String)
+
+Register an installable version. `urlpath` is resolved against the server base, so pass a relative
+path when the tarballs are served from the same host and an absolute URL otherwise.
+"""
+function add_version!(db::VersionDB, fullversion::AbstractString, urlpath::AbstractString)
+    db.versions[fullversion] = urlpath
+    return db
+end
+
+"""
+    add_channel!(db::VersionDB, channel::String, fullversion::String)
+
+Point `channel` at an already registered version. A channel referring to an unknown version would
+leave `juliaup` reporting a missing download url only once a user tries to install it.
+"""
+function add_channel!(db::VersionDB, channel::AbstractString, fullversion::AbstractString)
+
+    if !haskey(db.versions, fullversion)
+        error("Can not add channel `$channel`: version `$fullversion` is not in the database. " *
+              "Register it with `add_version!` first.")
+    end
+
+    db.channels[channel] = fullversion
+
+    return db
+end
+
+"""
+    merge(base::VersionDB, overlay::VersionDB) -> VersionDB
+
+Combine two databases, with `overlay` winning on conflicts and providing the resulting database
+version. This is how a mirror keeps the stock channels working while adding its own.
+"""
+function Base.merge(base::VersionDB, overlay::VersionDB)
+    return VersionDB(merge(base.versions, overlay.versions),
+                     merge(base.channels, overlay.channels),
+                     overlay.dbversion)
+end
+
+"""
+    next_dbversion(upstream::VersionNumber, published::VersionNumber = upstream) -> VersionNumber
+
+Return a database version greater than both `upstream` and whatever was `published` previously.
+
+`juliaup` replaces its cached database only when the number it reads exceeds both the number
+compiled into its own binary and its local copy, and it logs nothing when it does not. Publishing
+at or below the public number therefore makes a distribution invisible with no diagnostic at all.
+"""
+function next_dbversion(upstream::VersionNumber, published::VersionNumber = upstream)
+
+    highest = max(upstream, published)
+
+    return VersionNumber(highest.major, highest.minor, highest.patch + 1)
+end
+
+"""
+    fetch_dbversion(; server = DEFAULT_SERVER, channel = :release) -> VersionNumber
+
+Download the database version a server currently advertises for `channel`, which is one of
+`:release`, `:releasepreview` or `:dev`.
+"""
+function fetch_dbversion(; server::AbstractString = DEFAULT_SERVER, channel::Symbol = :release)
+
+    name = channel === :release ? "RELEASECHANNELDBVERSION" :
+           channel === :releasepreview ? "RELEASEPREVIEWCHANNELDBVERSION" :
+           channel === :dev ? "DEVCHANNELDBVERSION" :
+           error("Unknown juliaup channel `$channel`. Expected :release, :releasepreview or :dev.")
+
+    destination = tempname()
+
+    Downloads.download(rstrip(server, '/') * "/juliaup/" * name, destination)
+
+    return VersionNumber(strip(read(destination, String)))
+end
+
+"""
+    fetch_versiondb(target::String; server = DEFAULT_SERVER, dbversion) -> VersionDB
+
+Download the version database a `juliaup` client with the given target triple would read.
+"""
+function fetch_versiondb(target::AbstractString;
+                         server::AbstractString = DEFAULT_SERVER,
+                         dbversion::VersionNumber = fetch_dbversion(; server))
+
+    target in JULIAUP_TARGETS || error("`$target` is not a juliaup target triple")
+
+    url = rstrip(server, '/') * "/juliaup/versiondb/versiondb-$dbversion-$target.json"
+    destination = tempname()
+
+    Downloads.download(url, destination)
+
+    return read_versiondb(destination)
+end
+
+"""
+    fetch_upstream(; server = DEFAULT_SERVER, dbversion) -> Dict{String, VersionDB}
+
+Download the version database for every target triple, keyed by triple. This is the base a mirror
+merges its own channels into.
+"""
+function fetch_upstream(; server::AbstractString = DEFAULT_SERVER,
+                        dbversion::VersionNumber = fetch_dbversion(; server))
+
+    @info "Fetching upstream juliaup databases at $dbversion from $server"
+
+    return Dict{String, VersionDB}(target => fetch_versiondb(target; server, dbversion)
+                                   for target in JULIAUP_TARGETS)
+end

--- a/src/Tarball/TarPack.jl
+++ b/src/Tarball/TarPack.jl
@@ -11,11 +11,16 @@ import CodecZlib: GzipCompressorStream
 # freshly created `<parent>/<name>`), since we tar the parent to capture the
 # folder prefix. Tar.create records the owner-execute bit, so the launchers and
 # install.sh stay executable; symlinks in the Julia tree are preserved as-is.
+#
+# The single root is also what makes the archive installable by juliaup, which unpacks a
+# distribution with `download_extract_sans_parent(url, dir, 1)` — exactly one leading path
+# component is stripped — and then looks for the interpreter at `<root>/bin/julia`.
 function pack(rootdir, destination)
     parent = dirname(rootdir)
     name = basename(rootdir)
-    only(readdir(parent)) == name ||
-        error("TarPack.pack expects $parent to contain only $name")
+    entries = readdir(parent)
+    entries == [name] ||
+        error("TarPack.pack expects $parent to contain only $name, found: $(join(entries, ", "))")
 
     open(destination, "w") do io
         stream = GzipCompressorStream(io)

--- a/src/Tarball/TarPack.jl
+++ b/src/Tarball/TarPack.jl
@@ -1,0 +1,32 @@
+module TarPack
+
+import Tar
+import CodecZlib: GzipCompressorStream
+
+# Pack `rootdir` into a gzip-compressed tar at `destination`, with `rootdir`'s
+# basename as the archive's single top-level folder (so `tar xzf` extracts into
+# `<app>-<version>-<arch>/` instead of spilling bin/, lib/, … into the cwd).
+#
+# `rootdir` must be the only entry inside its parent (the caller stages into a
+# freshly created `<parent>/<name>`), since we tar the parent to capture the
+# folder prefix. Tar.create records the owner-execute bit, so the launchers and
+# install.sh stay executable; symlinks in the Julia tree are preserved as-is.
+function pack(rootdir, destination)
+    parent = dirname(rootdir)
+    name = basename(rootdir)
+    only(readdir(parent)) == name ||
+        error("TarPack.pack expects $parent to contain only $name")
+
+    open(destination, "w") do io
+        stream = GzipCompressorStream(io)
+        try
+            Tar.create(parent, stream)
+        finally
+            close(stream)
+        end
+    end
+
+    return
+end
+
+end

--- a/src/bundle.jl
+++ b/src/bundle.jl
@@ -178,37 +178,54 @@ function Snap(overlay; preferences = preferences(), kwargs...)
     return snap
 end
 
-# Plain relocatable directory tree, shipped as a .tar.gz with an install.sh.
-# Unlike Snap it carries no sandbox runtime: it runs from wherever it is
-# unpacked (e.g. /opt), relying on the launcher to set USER_DATA and on packages
-# resolving their assets relocatably (pkgdir, not @__DIR__).
+# Plain relocatable directory tree, shipped as a .tar.gz. Unlike Snap it carries
+# no sandbox runtime: it runs from wherever it is unpacked (e.g. /opt, a user
+# folder), relying on the launcher to set USER_DATA and on packages resolving
+# their assets relocatably (pkgdir, not @__DIR__).
+#
+# Cross-platform: `os` (:linux | :macos | :windows) selects the staged Julia
+# platform, the launcher (a POSIX `*.sh` for linux/macos, a `*.bat` for
+# windows) and the installer (`install.sh` vs `install.ps1`). The `.desktop`
+# entry is linux-only. Packing is always `.tar.gz` (Windows 10+ ships `tar`),
+# so the same TarPack path serves every OS.
 struct Tarball
     icon::String
-    desktop_launcher::String
-    install_script::String
+    desktop_launcher::Union{String, Nothing}
+    install_script::Union{String, Nothing}
     main_launcher::Union{String, Nothing}
     windowed::Bool
     compress::Bool
     arch::Symbol
+    os::Symbol
     predicate::String
     parameters::Dict{String, Any}
 end
+
+# Default target OS = the host (cross-compiling a sysimage isn't supported, so
+# each OS bundle must be built on a matching runner anyway).
+host_os() = Sys.iswindows() ? :windows : Sys.isapple() ? :macos : :linux
 
 function Tarball(;
                  prefix = joinpath(dirname(@__DIR__), "recipes"),
                  preferences = preferences(),
                  predicate = preferences["bundler"],
+                 os = host_os(),
                  icon = get_path(prefix, ["tarball/icon.png", "icon.png"]),
-                 desktop_launcher = get_path(prefix, ["tarball/main.desktop", "snap/main.desktop"]),
-                 install_script = get_path(prefix, "tarball/install.sh"),
-                 main_launcher = get_path(prefix, hook("tarball/main.sh", predicate); warn = false),
+                 desktop_launcher = os === :linux ?
+                     get_path(prefix, ["tarball/main.desktop", "snap/main.desktop"]) : nothing,
+                 install_script = os === :windows ?
+                     get_path(prefix, "tarball/install.ps1"; warn = false) :
+                     get_path(prefix, "tarball/install.sh"),
+                 main_launcher = os === :windows ?
+                     get_path(prefix, hook("tarball/main.bat", predicate); warn = false) :
+                     get_path(prefix, hook("tarball/main.sh", predicate); warn = false),
                  windowed = preferences["windowed"],
                  compress = preferences["compress"],
                  arch = Sys.ARCH,
                  parameters = Dict("WINDOWED" => windowed)
                  )
 
-    return Tarball(icon, desktop_launcher, install_script, main_launcher, windowed, compress, arch, predicate, parameters)
+    return Tarball(icon, desktop_launcher, install_script, main_launcher, windowed, compress, arch, os, predicate, parameters)
 end
 
 function Tarball(overlay; preferences = preferences(), kwargs...)
@@ -485,15 +502,28 @@ end
 
 function stage(tarball::Tarball, destination::String)
 
-    (; predicate, parameters) = tarball
+    (; predicate, parameters, os) = tarball
     app_name = parameters["APP_NAME"]
 
     install(tarball.icon, joinpath(destination, "meta/icon.png"))
-    install(tarball.desktop_launcher, joinpath(destination, "meta/gui/$app_name.desktop"); parameters, predicate)
-    install(tarball.install_script, joinpath(destination, "install.sh"); parameters, executable = true, predicate)
 
+    # `.desktop` integration is linux-only.
+    if !isnothing(tarball.desktop_launcher)
+        install(tarball.desktop_launcher, joinpath(destination, "meta/gui/$app_name.desktop"); parameters, predicate)
+    end
+
+    # Installer name matches its interpreter so the unpacked tree is obviously
+    # runnable: install.sh on unix, install.ps1 on windows.
+    if !isnothing(tarball.install_script)
+        install_name = os === :windows ? "install.ps1" : "install.sh"
+        install(tarball.install_script, joinpath(destination, install_name); parameters, executable = (os !== :windows), predicate)
+    end
+
+    # Launcher lands in bin/ next to the bundled julia: `<app>` (a bash script,
+    # resolved via a PATH symlink) on unix, `<app>.bat` on windows.
     if !isnothing(tarball.main_launcher)
-        install(tarball.main_launcher, joinpath(destination, "bin/$app_name"); parameters, executable = true, predicate)
+        launcher_rel = os === :windows ? "bin/$app_name.bat" : "bin/$app_name"
+        install(tarball.main_launcher, joinpath(destination, launcher_rel); parameters, executable = (os !== :windows), predicate)
     end
 
     return

--- a/src/bundle.jl
+++ b/src/bundle.jl
@@ -178,6 +178,48 @@ function Snap(overlay; preferences = preferences(), kwargs...)
     return snap
 end
 
+# Plain relocatable directory tree, shipped as a .tar.gz with an install.sh.
+# Unlike Snap it carries no sandbox runtime: it runs from wherever it is
+# unpacked (e.g. /opt), relying on the launcher to set USER_DATA and on packages
+# resolving their assets relocatably (pkgdir, not @__DIR__).
+struct Tarball
+    icon::String
+    desktop_launcher::String
+    install_script::String
+    main_launcher::Union{String, Nothing}
+    windowed::Bool
+    compress::Bool
+    arch::Symbol
+    predicate::String
+    parameters::Dict{String, Any}
+end
+
+function Tarball(;
+                 prefix = joinpath(dirname(@__DIR__), "recipes"),
+                 preferences = preferences(),
+                 predicate = preferences["bundler"],
+                 icon = get_path(prefix, ["tarball/icon.png", "icon.png"]),
+                 desktop_launcher = get_path(prefix, ["tarball/main.desktop", "snap/main.desktop"]),
+                 install_script = get_path(prefix, "tarball/install.sh"),
+                 main_launcher = get_path(prefix, hook("tarball/main.sh", predicate); warn = false),
+                 windowed = preferences["windowed"],
+                 compress = preferences["compress"],
+                 arch = Sys.ARCH,
+                 parameters = Dict("WINDOWED" => windowed)
+                 )
+
+    return Tarball(icon, desktop_launcher, install_script, main_launcher, windowed, compress, arch, predicate, parameters)
+end
+
+function Tarball(overlay; preferences = preferences(), kwargs...)
+
+    prefix = [overlay, joinpath(overlay, "meta"), joinpath(dirname(@__DIR__), "recipes")]
+    tarball = Tarball(; prefix, preferences, kwargs...)
+    get_bundle_parameters!(tarball.parameters, joinpath(overlay, "Project.toml"); preferences)
+
+    return tarball
+end
+
 # TODO: mention that application needs to be notarized by Apple. That can be done outside the build process by stapling already signed DMG archive. 
 
 """
@@ -441,6 +483,22 @@ function stage(snap::Snap, destination::String)
     return
 end
 
+function stage(tarball::Tarball, destination::String)
+
+    (; predicate, parameters) = tarball
+    app_name = parameters["APP_NAME"]
+
+    install(tarball.icon, joinpath(destination, "meta/icon.png"))
+    install(tarball.desktop_launcher, joinpath(destination, "meta/gui/$app_name.desktop"); parameters, predicate)
+    install(tarball.install_script, joinpath(destination, "install.sh"); parameters, executable = true, predicate)
+
+    if !isnothing(tarball.main_launcher)
+        install(tarball.main_launcher, joinpath(destination, "bin/$app_name"); parameters, executable = true, predicate)
+    end
+
+    return
+end
+
 
 """
     bundle(setup::Function, config, destination::String; force=false, [password=""])
@@ -602,6 +660,41 @@ function bundle(setup::Function, snap::Snap, destination::String; force = false)
     if snap.compress
         @info "Packaging staging area into Snap..."
         SnapPack.pack(app_stage, destination)
+    end
+
+    return
+end
+
+function bundle(setup::Function, tarball::Tarball, destination::String; force = false)
+
+    if ispath(destination)
+        if force
+            rm(destination; force=true, recursive=true)
+        else
+            error("Destination $destination already exists. Use `force = true` argument.")
+        end
+    end
+
+    # When compressing, stage into `<tmp>/<rootname>` so the archive has a single
+    # top-level folder (TarPack tars the parent). Uncompressed, the destination
+    # directory itself is the staging area.
+    if tarball.compress
+        rootname = replace(basename(destination), r"\.tar\.gz$" => "")
+        staging_parent = mktempdir()
+        app_stage = joinpath(staging_parent, rootname)
+        mkpath(app_stage)
+    else
+        app_stage = destination
+    end
+
+    @info "Initializing tarball staging layout..."
+    stage(tarball, app_stage)
+    @info "Installing app into staging area..."
+    setup(app_stage)
+
+    if tarball.compress
+        @info "Packaging staging area into tar.gz..."
+        TarPack.pack(app_stage, destination)
     end
 
     return

--- a/src/bundle.jl
+++ b/src/bundle.jl
@@ -178,16 +178,43 @@ function Snap(overlay; preferences = preferences(), kwargs...)
     return snap
 end
 
-# Plain relocatable directory tree, shipped as a .tar.gz. Unlike Snap it carries
-# no sandbox runtime: it runs from wherever it is unpacked (e.g. /opt, a user
-# folder), relying on the launcher to set USER_DATA and on packages resolving
-# their assets relocatably (pkgdir, not @__DIR__).
-#
-# Cross-platform: `os` (:linux | :macos | :windows) selects the staged Julia
-# platform, the launcher (a POSIX `*.sh` for linux/macos, a `*.bat` for
-# windows) and the installer (`install.sh` vs `install.ps1`). The `.desktop`
-# entry is linux-only. Packing is always `.tar.gz` (Windows 10+ ships `tar`),
-# so the same TarPack path serves every OS.
+"""
+    Tarball([overlay]; os, arch, compress, windowed, kwargs...)
+
+Create a tarball configuration object for distributing an application as a relocatable `.tar.gz`.
+
+Unlike the installer formats a tarball is unsigned and installs nothing: it runs from wherever it is
+unpacked, relying on the bundled launcher to set `USER_DATA` and on packages resolving their assets
+relocatably (`pkgdir`, not `@__DIR__`). It is also the format a `juliaup` distribution is built
+from — the archive always carries a single top-level directory with the interpreter at
+`<root>/bin/julia`, which is what `juliaup` expects. See [Juliaup](@ref).
+
+`os` selects the staged Julia platform, the launcher (a POSIX `*.sh` for linux and macos, a `*.bat`
+for windows) and the installer (`install.sh` vs `install.ps1`). The `.desktop` entry is linux only.
+Packing is always `.tar.gz` — Windows 10 and later ship `tar` — so one code path serves every OS.
+
+# Arguments
+- `overlay`: Path to a project directory containing `Project.toml`, optional `LocalPreferences.toml`, and optional `meta/tarball/` overrides
+
+# Keyword Arguments
+- `prefix = joinpath(dirname(@__DIR__), "recipes")`: Base directory or array of directories to search for configuration files in sequential order
+- `os = host_os()`: Target operating system, one of `:linux`, `:macos` or `:windows`. Must match the host when a sysimage is compiled
+- `arch = Sys.ARCH`: Target CPU architecture
+- `icon = get_path(prefix, ["tarball/icon.png", "icon.png"])`: Path to application icon file
+- `desktop_launcher`: Desktop entry template; linux only
+- `install_script`: Installer placed at the archive root, `install.sh` or `install.ps1`
+- `main_launcher`: Launcher installed into `bin/`; resolved from prefix using the bundler predicate
+- `windowed`: If `true`, the application runs without a console window; defaults to `windowed` preference
+- `compress`: If `true`, pack the staging directory into a `.tar.gz`; defaults to `compress` preference
+- `predicate`: Bundler predicate used for hook selection; defaults to `bundler` preference
+- `parameters`: Dictionary of parameters for Mustache template rendering. When `overlay` is provided, pre-populated from `Project.toml` and preferences
+
+# Examples
+```julia
+Tarball(app_dir)                                  # host platform
+Tarball(app_dir; os = :macos, arch = :aarch64)
+```
+"""
 struct Tarball
     icon::String
     desktop_launcher::Union{String, Nothing}
@@ -635,6 +662,12 @@ function bundle(setup::Function, dmg::DMG, destination::String; force = false, p
 end
 
 """
+    bundle(setup::Function, msix::MSIX, destination::String; force = false, password = "")
+
+MSIX variant of [`bundle(setup, config, destination)`](@ref).
+
+Before packing, the staging area is checked against the constraints Windows places on an app
+package — path length, symlinks and non-ASCII paths — according to the `MSIX` configuration.
 """
 function bundle(setup::Function, msix::MSIX, destination::String; force = false, password = "")
 

--- a/src/bundlers/JuliaImg/JuliaImg.jl
+++ b/src/bundlers/JuliaImg/JuliaImg.jl
@@ -85,6 +85,8 @@ pkg = JuliaImgBundle("path/to/app"; sysimg_packages = ["Plots", "DifferentialEqu
     sysimg_packages::Vector{String} = []
     sysimg_args::Cmd = ``
     remove_sources::Bool = false # ToDo: It only makes sense to remove sources for packages baked in the sysimg
+    strip_debug::Bool = false # strip DWARF debug info from the staged Julia runtime libs (lib/julia)
+    strip_docs::Bool = false  # drop docs/test/examples from staged packages + Julia's share/doc·test·man
     asset_rpath::String = "assets"
     asset_spec::Dict{Symbol, Vector{String}} = Dict{Symbol, Vector{String}}()
     precompile::Bool = true
@@ -497,6 +499,12 @@ function stage(product::JuliaImgBundle, destination::String; platform::AbstractP
         cp(joinpath(product.source, "Project.toml"), joinpath(packages_dir, stdlib_project_name, "Project.toml"))
     end
 
+    # Size reduction passes. Run AFTER sysimg/pkgimg compilation: strip_debug!
+    # must see the freshly built sys image, and neither touches the depot's
+    # content-validated pkgimages (compiled/), only lib/julia and package trees.
+    product.strip_debug && strip_debug!(destination, platform)
+    product.strip_docs  && strip_docs!(destination, product)
+
     if isempty(product.asset_spec)
         Resources.install_pkgorigin_index(product.source, joinpath(destination, "index"), product.stdlib_dir)
     else
@@ -512,6 +520,74 @@ function stage(product::JuliaImgBundle, destination::String; platform::AbstractP
         println("Launch it with bin/julia")
     end
 
+    return
+end
+
+# Strip DWARF debug info from the staged Julia runtime libraries in lib/julia
+# (sys image + libjulia-codegen/libLLVM/libstdc++/…). NEVER touches the depot's
+# compiled/ pkgimages — those are content-validated and editing them forces a
+# recompile on first launch. Scoping to lib/julia naturally avoids them.
+#
+# Cross-build safe: prefers `llvm-strip` (handles ELF/Mach-O/COFF from any host),
+# falling back to host `strip`. `-S` (remove debug symbols/sections) is the one
+# flag understood by GNU strip, BSD/macOS strip, and llvm-strip alike. Windows
+# keeps debug info in separate .pdb files, so there we just delete those.
+function strip_debug!(destination, platform)
+    tos = string(os(platform))
+    if tos == "windows"
+        for base in (joinpath(destination, "lib", "julia"), joinpath(destination, "bin"))
+            isdir(base) || continue
+            for (root, _, files) in walkdir(base), f in files
+                endswith(lowercase(f), ".pdb") && rm(joinpath(root, f))
+            end
+        end
+        return
+    end
+
+    libdir = joinpath(destination, "lib", "julia")
+    isdir(libdir) || return
+    # Match .so, .so.N.M…, AND Julia's jl-ABI-suffixed libs (e.g. libLLVM.so.18.1jl).
+    # `\.so($|\.)` = ".so" at end, or ".so." followed by any version/ABI tail.
+    matches = tos == "macos" ? (f -> occursin(r"\.dylib$", f)) :
+                               (f -> occursin(r"\.so($|\.)", f))
+    stripper = something(Sys.which("llvm-strip"), Sys.which("strip"), Some(nothing))
+    if stripper === nothing
+        @warn "strip_debug!: no llvm-strip/strip on PATH; skipping debug stripping"
+        return
+    end
+    for (root, _, files) in walkdir(libdir), f in files
+        p = joinpath(root, f)
+        islink(p) && continue          # don't rewrite the .so/.so.N symlink aliases
+        matches(f) || continue
+        try
+            run(`$stripper -S $p`)
+        catch e
+            @warn "strip_debug!: failed to strip $p" exception = e
+        end
+    end
+    return
+end
+
+# Drop documentation/test/example trees from the staged package source tree, plus
+# Julia's own share/doc · share/julia/test · share/man. Unlike remove_sources,
+# this KEEPS each package's src/ so a pkgimage that ever gets invalidated can
+# still recompile. Pure directory removal — host-agnostic, identical per target.
+const STRIP_DOC_DIRS = ("docs", "test", "examples", "benchmark", "benchmarks")
+function strip_docs!(destination, product)
+    pkgs = joinpath(destination, product.stdlib_dir)
+    if isdir(pkgs)
+        for pkg in readdir(pkgs; join = true)
+            isdir(pkg) || continue
+            for sub in STRIP_DOC_DIRS
+                d = joinpath(pkg, sub)
+                isdir(d) && rm(d; recursive = true)
+            end
+        end
+    end
+    for rel in ("share/doc", joinpath("share", "julia", "test"), joinpath("share", "man"))
+        p = joinpath(destination, rel)
+        ispath(p) && rm(p; recursive = true)
+    end
     return
 end
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -34,8 +34,9 @@ end
 suffix(msix::MSIX) = msix.compress ? ".msix" : ""
 suffix(dmg::DMG) = dmg.compress ? ".dmg" : ""
 suffix(snap::Snap) = snap.compress ? ".snap" : ""
+suffix(tarball::Tarball) = tarball.compress ? ".tar.gz" : ""
 
-function canonical_target_name(spec::Union{MSIX, DMG, Snap})
+function canonical_target_name(spec::Union{MSIX, DMG, Snap, Tarball})
     version = spec.parameters["APP_VERSION"]
     app_name = spec.parameters["APP_NAME"]
     return "$(app_name)-$version-$(spec.arch)"
@@ -130,6 +131,11 @@ function main_build(ARGS; sources_dir)
 
         snap = Snap(sources_dir; arch = target_arch, preferences)
         bundle(spec, snap, target_path(snap); force = overwrite_target)
+
+    elseif :tarball == target_bundle
+
+        tarball = Tarball(sources_dir; arch = target_arch, preferences)
+        bundle(spec, tarball, target_path(tarball); force = overwrite_target)
 
     else
         error("Got unsupported bundle type $target_bundle")
@@ -333,9 +339,12 @@ Options:
   --build-dir DIR                   Output directory for the bundle
                                     (default: temporary directory)
                                     Use '@temp' to explicitly request a temp dir
-  --target-bundle {dmg|snap|msix}   Package format to produce
+  --target-bundle {dmg|snap|tarball|msix}
+                                    Package format to produce
                                     (default: platform native — dmg on macOS,
-                                    snap on Linux, msix on Windows)
+                                    snap on Linux, msix on Windows). `tarball`
+                                    (Linux) produces a relocatable .tar.gz with
+                                    an install.sh (no snapd required).
   --target-arch {x86_64|aarch64}    Target CPU architecture
                                     (default: current system architecture)
   --target-name NAME                Override the output file/directory name

--- a/src/main.jl
+++ b/src/main.jl
@@ -21,6 +21,14 @@ function (@main)(ARGS)
 
         main_build(ARGS[3:end]; sources_dir = realpath(ARGS[2]))
 
+    elseif command == "juliaup"
+
+        if length(ARGS) < 2
+            error("No project path provided for `juliaup` command. See `--help` for usage.")
+        end
+
+        main_juliaup(ARGS[3:end]; sources_dir = realpath(ARGS[2]))
+
     # elseif command == "init"
     #     ...
 
@@ -36,10 +44,19 @@ suffix(dmg::DMG) = dmg.compress ? ".dmg" : ""
 suffix(snap::Snap) = snap.compress ? ".snap" : ""
 suffix(tarball::Tarball) = tarball.compress ? ".tar.gz" : ""
 
-function canonical_target_name(spec::Union{MSIX, DMG, Snap, Tarball})
+function canonical_target_name(spec::Union{MSIX, DMG, Snap})
     version = spec.parameters["APP_VERSION"]
     app_name = spec.parameters["APP_NAME"]
     return "$(app_name)-$version-$(spec.arch)"
+end
+
+# Unlike the installer formats a tarball is produced for every operating system, so the name
+# carries the OS as well. Without it a release matrix uploads three different archives under
+# the same asset name, and the juliaup database can not tell them apart.
+function canonical_target_name(spec::Tarball)
+    version = spec.parameters["APP_VERSION"]
+    app_name = spec.parameters["APP_NAME"]
+    return "$(app_name)-$version-$(spec.os)-$(spec.arch)"
 end
 
 function main_build(ARGS; sources_dir)
@@ -145,6 +162,119 @@ function main_build(ARGS; sources_dir)
     end
 
     return
+end
+
+"""
+    main_juliaup(ARGS; sources_dir)
+
+Implements `appbundler juliaup <project_dir>`: writes the static file tree a `juliaup` client
+reads, so a distribution built with `--target-bundle=tarball` can be installed with
+`juliaup add <channel>`.
+
+Intended to run once per release, after the build matrix has uploaded its tarballs.
+"""
+function main_juliaup(ARGS; sources_dir)
+
+    config, preference_overrides = parse_juliaup_args(ARGS)
+    project_preferences = Resources.get_project_preferences(sources_dir)
+    preferences = merge(project_preferences["AppBundler"], preference_overrides)
+
+    # Only the flags that were actually given override the project's preferences.
+    overrides = Dict{Symbol, Any}(key => config[key]
+                                  for key in [:channel, :server, :asset_base, :mirror, :dbversion]
+                                  if !isnothing(config[key]))
+
+    dist = Juliaup.JuliaupDistribution(sources_dir; preferences, overrides...)
+
+    site = config[:build_dir]
+
+    Juliaup.publish(dist, site; assets = config[:platforms])
+
+    if config[:wrappers]
+        Juliaup.install_wrappers(dist, joinpath(site, "wrappers"))
+    end
+
+    println("""
+
+    The juliaup site is ready at $site. Serve it over HTTPS, then users can install the
+    distribution with:
+
+        export JULIAUP_SERVER=$(isempty(dist.server) ? "https://your.site" : dist.server)
+        juliaup add $(dist.channel)
+        julia +$(dist.channel)
+    """)
+
+    return
+end
+
+function parse_juliaup_args(raw_args)
+
+    args = normalize_args(raw_args)
+
+    config = Dict{Symbol, Any}(:build_dir => mktempdir(),
+                               :channel => nothing,
+                               :server => nothing,
+                               :asset_base => nothing,
+                               :dbversion => nothing,
+                               :mirror => nothing,
+                               :wrappers => false,
+                               :platforms => Tuple{Symbol, Symbol}[])
+
+    preference_overrides = String[]
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+        if arg in ["--help", "-h"]
+            print_help()
+            exit(0)
+        elseif arg == "--build-dir"
+            i += 1
+            i > length(args) && error("--build-dir requires a value")
+            build_dir = expanduser(args[i])
+            config[:build_dir] = build_dir == "@temp" ? mktempdir() : (mkpath(build_dir); abspath(build_dir))
+        elseif arg == "--channel"
+            i += 1
+            i > length(args) && error("--channel requires a value")
+            config[:channel] = args[i]
+        elseif arg == "--server"
+            i += 1
+            i > length(args) && error("--server requires a value")
+            config[:server] = args[i]
+        elseif arg == "--asset-base"
+            i += 1
+            i > length(args) && error("--asset-base requires a value")
+            config[:asset_base] = args[i]
+        elseif arg == "--dbversion"
+            i += 1
+            i > length(args) && error("--dbversion requires a value")
+            config[:dbversion] = VersionNumber(args[i])
+        elseif arg == "--no-mirror"
+            config[:mirror] = false
+        elseif arg == "--mirror"
+            config[:mirror] = true
+        elseif arg == "--wrappers"
+            config[:wrappers] = true
+        elseif arg == "--platform"
+            i += 1
+            i > length(args) && error("--platform requires a value of the form <os>/<arch>")
+            parts = split(args[i], '/')
+            length(parts) == 2 || error("--platform expects <os>/<arch>, got `$(args[i])`")
+            push!(config[:platforms], (Symbol(parts[1]), Symbol(parts[2])))
+        elseif arg == "-D"
+            i += 1
+            push!(preference_overrides, args[i])
+        else
+            @warn "Unknown argument: $arg"
+        end
+        i += 1
+    end
+
+    if isempty(config[:platforms])
+        push!(config[:platforms], (host_os(), Sys.ARCH))
+    end
+
+    return config, TOML.parse(join(preference_overrides, "\n"))
 end
 
 function get_project_name(project_toml)
@@ -342,7 +472,8 @@ end
 
 
 const HELP_TEXT = """
-Usage: appbundler build <project_dir> [OPTIONS]
+Usage: appbundler build   <project_dir> [OPTIONS]
+       appbundler juliaup <project_dir> [OPTIONS]
 
 Arguments:
   <project_dir>                     Path to the Julia project to bundle
@@ -384,6 +515,31 @@ Examples:
   appbundler build . --target-bundle=snap --target-arch=aarch64
   appbundler build . --selfsign --password=secret
   appbundler build . -Dbundler="juliac" -Djuliac_trim=true
+
+Juliaup options (appbundler juliaup):
+  --build-dir DIR                   Output directory for the static site
+  --channel NAME                    Channel users pass to `juliaup add`
+                                    (default: <app-name>-<app-version>)
+  --server URL                      HTTPS base url the site will be served from;
+                                    written into the client wrappers
+  --asset-base URL                  Base url or path the tarballs are served
+                                    from. Relative keeps the database portable
+                                    across hosts; absolute points elsewhere,
+                                    such as a GitHub releases page
+  --platform OS/ARCH                A platform that was built; repeatable
+                                    (default: the host platform)
+  --dbversion VERSION               Database version to publish. Must exceed the
+                                    public one or juliaup silently ignores it
+                                    (resolved automatically when omitted)
+  --mirror / --no-mirror            Merge the upstream database in so the stock
+                                    channels keep working (default: mirror)
+  --wrappers                        Also write the client wrappers into the site
+
+Examples:
+  appbundler juliaup . --build-dir=site --platform=linux/x86_64
+  appbundler juliaup . --build-dir=site --server=https://acme.github.io/myapp \\
+      --asset-base=https://github.com/acme/myapp/releases/download/v1.2.0 \\
+      --platform=linux/x86_64 --platform=macos/aarch64 --wrappers
 """
 
 function print_help()

--- a/src/main.jl
+++ b/src/main.jl
@@ -49,6 +49,7 @@ function main_build(ARGS; sources_dir)
     preferences = merge(project_preferences["AppBundler"], preference_overrides)
 
     target_arch = config[:target_arch]
+    target_os = config[:target_os]
     target_bundle = config[:target_bundle]
     build_dir = config[:build_dir]
     password = config[:password]
@@ -134,7 +135,7 @@ function main_build(ARGS; sources_dir)
 
     elseif :tarball == target_bundle
 
-        tarball = Tarball(sources_dir; arch = target_arch, preferences)
+        tarball = Tarball(sources_dir; arch = target_arch, os = target_os, preferences)
         bundle(spec, tarball, target_path(tarball); force = overwrite_target)
 
     else
@@ -254,6 +255,7 @@ function parse_args(raw_args) #; preferences = Base.get_preferences()["AppBundle
     config = Dict(
         :build_dir => mktempdir(),  # Use nothing to distinguish "not set" from ""
         :target_arch => Sys.ARCH,
+        :target_os => Sys.islinux() ? :linux : Sys.isapple() ? :macos : Sys.iswindows() ? :windows : error("Bundling for current platform is unsupported"),
         :target_bundle => Sys.islinux() ? :snap : Sys.isapple() ? :dmg : Sys.iswindows() ? :msix : error("Bundling for current platform is unsupported"),
         :target_name => nothing,
         :password => nothing
@@ -310,6 +312,14 @@ function parse_args(raw_args) #; preferences = Base.get_preferences()["AppBundle
                 error("--target-arch requires a value")
             end
             config[:target_arch] = Symbol(args[i])
+        elseif arg == "--target-os"
+            i += 1
+            if i > length(args)
+                error("--target-os requires a value")
+            end
+            os = Symbol(args[i])
+            os in (:linux, :macos, :windows) || error("--target-os must be one of: linux, macos, windows")
+            config[:target_os] = os
         elseif arg == "--target-bundle"
             i += 1
             if i > length(args)
@@ -343,10 +353,15 @@ Options:
                                     Package format to produce
                                     (default: platform native — dmg on macOS,
                                     snap on Linux, msix on Windows). `tarball`
-                                    (Linux) produces a relocatable .tar.gz with
-                                    an install.sh (no snapd required).
+                                    produces a relocatable, unsigned .tar.gz on
+                                    every OS (install.sh on linux/macos,
+                                    install.ps1 + a .bat launcher on windows;
+                                    no snapd / code-signing required).
   --target-arch {x86_64|aarch64}    Target CPU architecture
                                     (default: current system architecture)
+  --target-os {linux|macos|windows} Target OS for `tarball` (default: host OS;
+                                    must match the host — the sysimage is built
+                                    with the running Julia).
   --target-name NAME                Override the output file/directory name
                                     (default: derived from app name and version)
   --selfsign                        Sign the bundle with a self-signed certificate

--- a/src/main.jl
+++ b/src/main.jl
@@ -72,13 +72,15 @@ function main_build(ARGS; sources_dir)
             asset_spec = Dict{Symbol, Vector{String}}()
         end
 
-        spec = JuliaImgBundle(sources_dir; 
+        spec = JuliaImgBundle(sources_dir;
                               precompile = preferences["juliaimg_precompile"],
                               incremental = preferences["juliaimg_incremental"],
                               sysimg_packages = preferences["juliaimg_sysimg"],
+                              strip_debug = get(preferences, "juliaimg_strip_debug", false),
+                              strip_docs = get(preferences, "juliaimg_strip_docs", false),
                               remove_sources,
                               asset_spec
-                              ) 
+                              )
         
     elseif bundler == "juliac"
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -67,12 +67,20 @@ end
 
 function bundle(product::JuliaImgBundle, tarball::Tarball, destination::String; force = false)
 
+    platform = tarball.os === :windows ? Windows(tarball.arch) :
+               tarball.os === :macos   ? MacOS(tarball.arch)   :
+                                         Linux(tarball.arch)
+
+    if tarball.os !== host_os()
+        @warn "Building a $(tarball.os) tarball on $(host_os()): the sysimage is compiled with the host Julia, so this only works when host OS == target OS."
+    end
+
     bundle(tarball, destination; force) do app_stage
 
         app_name = tarball.parameters["APP_NAME"]
         bundle_identifier = tarball.parameters["BUNDLE_IDENTIFIER"]
 
-        stage(product, app_stage; platform = Linux(tarball.arch), runtime_mode = "SANDBOX", app_name, bundle_identifier)
+        stage(product, app_stage; platform, runtime_mode = "SANDBOX", app_name, bundle_identifier)
 
         install(product.startup_file, joinpath(app_stage, "etc/julia/startup.jl"); parameters = tarball.parameters, force = true)
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -65,6 +65,22 @@ function bundle(product::JuliaImgBundle, snap::Snap, destination::String; force 
     return
 end
 
+function bundle(product::JuliaImgBundle, tarball::Tarball, destination::String; force = false)
+
+    bundle(tarball, destination; force) do app_stage
+
+        app_name = tarball.parameters["APP_NAME"]
+        bundle_identifier = tarball.parameters["BUNDLE_IDENTIFIER"]
+
+        stage(product, app_stage; platform = Linux(tarball.arch), runtime_mode = "SANDBOX", app_name, bundle_identifier)
+
+        install(product.startup_file, joinpath(app_stage, "etc/julia/startup.jl"); parameters = tarball.parameters, force = true)
+
+    end
+
+    return
+end
+
 function normalize_executable(path::String)
 
     tempfile = joinpath(mktempdir(), basename(path))

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -180,3 +180,29 @@ function bundle(product::JuliaCBundle, msix::MSIX, destination::String; password
 
     return
 end
+
+"""
+    bundle(product::JuliaCBundle, tarball::Tarball, destination::String; force = false)
+
+Package a juliac-compiled executable as a relocatable `.tar.gz`.
+
+Note that unlike a [`JuliaImgBundle`](@ref) tarball this is not a Julia distribution — it ships a
+standalone executable rather than `bin/julia` — so it can be unpacked and run, but not installed
+through `juliaup`.
+"""
+function bundle(product::JuliaCBundle, tarball::Tarball, destination::String; force = false)
+
+    if tarball.os !== host_os()
+        @warn "Building a $(tarball.os) tarball on $(host_os()): juliac compiles with the host toolchain, so this only works when host OS == target OS."
+    end
+
+    bundle(tarball, destination; force) do app_stage
+
+        app_name = tarball.parameters["APP_NAME"]
+        bundle_identifier = tarball.parameters["BUNDLE_IDENTIFIER"]
+
+        stage(product, app_stage; runtime_mode = "SANDBOX", app_name, bundle_identifier)
+    end
+
+    return
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -100,6 +100,50 @@ function install_github_workflow(; root = dirname(Base.ACTIVE_PROJECT[]), force 
 end
 
 
+"""
+    install_juliaup_workflow(; root, force = false)
+
+Install the GitHub Actions workflow that publishes a juliaup distribution.
+
+The workflow builds a relocatable tarball on each platform runner, attaches them to the release,
+and deploys the version database to GitHub Pages. Because the database only names paths, the
+tarballs stay on the releases page and their bytes never pass through Pages.
+"""
+function install_juliaup_workflow(; root = dirname(Base.ACTIVE_PROJECT[]), force = false)
+
+    if !isfile(joinpath(root, "Project.toml"))
+        error("It appears $root does not contain a valid Julia project")
+    end
+
+    mkpath(joinpath(root, ".github/workflows"))
+
+    destination = joinpath(root, ".github/workflows/Juliaup.yml")
+
+    cp(joinpath(dirname(@__DIR__), "recipes/workflows/JuliaupPages.yml"), destination; force)
+
+    if Sys.isunix() # chmod on windows can segfault
+        chmod(destination, 0o666)
+    end
+
+    println("""
+    Setup done. Enable GitHub Pages for this repository with "GitHub Actions" as the source, then
+    publish a release: the workflow builds a tarball per platform, attaches them to the release and
+    deploys the juliaup database to Pages.
+
+    Users then install the distribution with:
+
+        export JULIAUP_SERVER=https://<owner>.github.io/<repo>
+        juliaup add <channel>
+
+    Note that juliaup ignores a database whose version is not greater than the one built into its
+    own binary, and says nothing when it does. AppBundler resolves that number against the public
+    database automatically. See the Juliaup section of the documentation for details.
+    """)
+
+    return
+end
+
+
 function generate_signing_certificates(; root = dirname(Base.ACTIVE_PROJECT[]), person_name = "AppBundler", country = "XX", validity_days = 365, force = false)
 
     password_macos = generate_macos_signing_certificate(root; person_name, country, validity_days, force)

--- a/test/fixtures/versiondb-1.0.92-x86_64-unknown-linux-gnu.json
+++ b/test/fixtures/versiondb-1.0.92-x86_64-unknown-linux-gnu.json
@@ -1,0 +1,49 @@
+{
+ "AvailableVersions": {
+  "1.10.12+0.x64.linux.gnu": {
+   "UrlPath": "bin/linux/x64/1.10/julia-1.10.12-linux-x86_64.tar.gz"
+  },
+  "1.11.9+0.x64.linux.gnu": {
+   "UrlPath": "bin/linux/x64/1.11/julia-1.11.9-linux-x86_64.tar.gz"
+  },
+  "1.12.7+0.x64.linux.gnu": {
+   "UrlPath": "bin/linux/x64/1.12/julia-1.12.7-linux-x86_64.tar.gz"
+  },
+  "1.12.7+0.x86.linux.gnu": {
+   "UrlPath": "bin/linux/x86/1.12/julia-1.12.7-linux-i686.tar.gz"
+  }
+ },
+ "AvailableChannels": {
+  "1.10": {
+   "Version": "1.10.12+0.x64.linux.gnu"
+  },
+  "1.11": {
+   "Version": "1.11.9+0.x64.linux.gnu"
+  },
+  "1.12": {
+   "Version": "1.12.7+0.x64.linux.gnu"
+  },
+  "1.12.7": {
+   "Version": "1.12.7+0.x64.linux.gnu"
+  },
+  "1.12.7~x64": {
+   "Version": "1.12.7+0.x64.linux.gnu"
+  },
+  "1.12.7~x86": {
+   "Version": "1.12.7+0.x86.linux.gnu"
+  },
+  "lts": {
+   "Version": "1.10.12+0.x64.linux.gnu"
+  },
+  "release": {
+   "Version": "1.12.7+0.x64.linux.gnu"
+  },
+  "release~x64": {
+   "Version": "1.12.7+0.x64.linux.gnu"
+  },
+  "release~x86": {
+   "Version": "1.12.7+0.x86.linux.gnu"
+  }
+ },
+ "Version": "1.0.92"
+}

--- a/test/juliaup.jl
+++ b/test/juliaup.jl
@@ -1,0 +1,363 @@
+import AppBundler
+import AppBundler.Juliaup
+import AppBundler.Juliaup: VersionDB, JULIAUP_TARGETS, DBVERSION_FILES
+
+using Test
+
+const FIXTURE = joinpath(@__DIR__, "fixtures", "versiondb-1.0.92-x86_64-unknown-linux-gnu.json")
+
+@testset "Build tag sanitization" begin
+
+    # `juliaup` splits the build metadata on "." and reads the second component as the
+    # architecture. A tag carrying dots shifts that index and the entry resolves to a
+    # bogus architecture, which is why JuliaHub moved from `dyad-2.1.0-rc3` to `dyad-2x1x0-rc3`.
+    @test Juliaup.sanitize_build_tag("2.1.0-rc3") == "2x1x0-rc3"
+    @test Juliaup.sanitize_build_tag("dyad-3.3.0") == "dyad-3x3x0"
+    @test Juliaup.sanitize_build_tag("3.2.0-next.87") == "3x2x0-nextx87"
+    @test Juliaup.sanitize_build_tag("0") == "0"
+
+    @test_throws ErrorException Juliaup.sanitize_build_tag("")
+    @test_throws ErrorException Juliaup.sanitize_build_tag("has space")
+end
+
+@testset "Full version strings" begin
+
+    @test Juliaup.platform_suffix(:linux, :x86_64) == "x64.linux.gnu"
+    @test Juliaup.platform_suffix(:linux, :i686) == "x86.linux.gnu"
+    @test Juliaup.platform_suffix(:linux, :aarch64) == "aarch64.linux.gnu"
+    @test Juliaup.platform_suffix(:macos, :x86_64) == "x64.apple.darwin14"
+    @test Juliaup.platform_suffix(:macos, :aarch64) == "aarch64.apple.darwin14"
+    @test Juliaup.platform_suffix(:windows, :x86_64) == "x64.w64.mingw32"
+    @test Juliaup.platform_suffix(:windows, :i686) == "x86.w64.mingw32"
+    @test Juliaup.platform_suffix(:freebsd, :x86_64) == "x64.unknown.freebsd11.1"
+
+    @test_throws ErrorException Juliaup.platform_suffix(:macos, :i686)
+    @test_throws ErrorException Juliaup.platform_suffix(:haiku, :x86_64)
+
+    # Matches the shape of upstream entries such as `1.12.7+0.x64.linux.gnu`
+    @test Juliaup.full_version_string(v"1.12.7", "0", :linux, :x86_64) == "1.12.7+0.x64.linux.gnu"
+
+    # Build tags are sanitized on the way in so callers cannot construct a broken entry
+    @test Juliaup.full_version_string(v"1.12.7", "myapp-1.2.0", :linux, :x86_64) ==
+        "1.12.7+myapp-1x2x0.x64.linux.gnu"
+
+    # The architecture must survive `juliaup`'s own parsing: build metadata split on ".",
+    # second component is the architecture.
+    for (os, arch, expected) in [(:linux, :x86_64, "x64"), (:macos, :aarch64, "aarch64"),
+                                 (:windows, :i686, "x86")]
+        parts = split(split(Juliaup.full_version_string(v"1.11.9", "app-2.0.0", os, arch), '+')[2], '.')
+        @test length(parts) >= 4
+        @test parts[2] == expected
+    end
+end
+
+@testset "Target triples" begin
+
+    @test length(JULIAUP_TARGETS) == 13
+    @test allunique(JULIAUP_TARGETS)
+    @test "x86_64-unknown-linux-gnu" in JULIAUP_TARGETS
+    @test "x86_64-unknown-linux-musl" in JULIAUP_TARGETS
+    @test "aarch64-apple-darwin" in JULIAUP_TARGETS
+    @test "x86_64-unknown-freebsd" in JULIAUP_TARGETS
+
+    # The triple describes the juliaup client binary, not the Julia build. The Linux client
+    # is musl-static but runs on glibc hosts, so a Linux build must land in both databases.
+    @test Set(Juliaup.targets_for(:linux, :x86_64)) ==
+        Set(["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"])
+
+    # A 32 bit build is also reachable from a 64 bit client
+    @test "x86_64-unknown-linux-gnu" in Juliaup.targets_for(:linux, :i686)
+    @test "i686-unknown-linux-gnu" in Juliaup.targets_for(:linux, :i686)
+    @test "i686-unknown-linux-gnu" ∉ Juliaup.targets_for(:linux, :x86_64)
+
+    # Rosetta 2: an x86_64 macOS build is installable from an Apple Silicon client
+    @test Set(Juliaup.targets_for(:macos, :x86_64)) ==
+        Set(["x86_64-apple-darwin", "aarch64-apple-darwin"])
+    @test Juliaup.targets_for(:macos, :aarch64) == ["aarch64-apple-darwin"]
+
+    @test Set(Juliaup.targets_for(:windows, :x86_64)) ==
+        Set(["x86_64-pc-windows-gnu", "x86_64-pc-windows-msvc"])
+
+    @test Juliaup.targets_for(:freebsd, :x86_64) == ["x86_64-unknown-freebsd"]
+
+    # Every target a build maps to must be one juliaup actually asks for
+    for os in [:linux, :macos, :windows, :freebsd], arch in [:x86_64, :i686, :aarch64]
+        targets = try
+            Juliaup.targets_for(os, arch)
+        catch
+            continue
+        end
+        @test all(in(JULIAUP_TARGETS), targets)
+    end
+end
+
+@testset "Version database round trip" begin
+
+    db = Juliaup.read_versiondb(FIXTURE)
+
+    @test db.dbversion == v"1.0.92"
+    @test db.channels["release"] == "1.12.7+0.x64.linux.gnu"
+    @test db.versions["1.12.7+0.x64.linux.gnu"] == "bin/linux/x64/1.12/julia-1.12.7-linux-x86_64.tar.gz"
+    @test length(db.versions) == 4
+    @test length(db.channels) == 10
+
+    # Internals are plain Dicts so the JSON implementation does not leak into the API
+    @test db.versions isa Dict{String, String}
+    @test db.channels isa Dict{String, String}
+
+    path = joinpath(mktempdir(), "versiondb.json")
+    Juliaup.write_versiondb(path, db)
+    reread = Juliaup.read_versiondb(path)
+
+    @test reread.versions == db.versions
+    @test reread.channels == db.channels
+    @test reread.dbversion == db.dbversion
+
+    # The serialized form must match what juliaup deserializes into
+    raw = read(path, String)
+    @test occursin("\"AvailableVersions\"", raw)
+    @test occursin("\"AvailableChannels\"", raw)
+    @test occursin("\"UrlPath\"", raw)
+    @test occursin("\"Version\"", raw)
+end
+
+@testset "Adding versions and channels" begin
+
+    db = Juliaup.read_versiondb(FIXTURE)
+    fullversion = Juliaup.full_version_string(v"1.12.7", "myapp-1.2.0", :linux, :x86_64)
+
+    Juliaup.add_version!(db, fullversion, "https://example.com/myapp-1.2.0-linux-x86_64.tar.gz")
+    Juliaup.add_channel!(db, "myapp-1.2.0", fullversion)
+
+    @test db.versions[fullversion] == "https://example.com/myapp-1.2.0-linux-x86_64.tar.gz"
+    @test db.channels["myapp-1.2.0"] == fullversion
+
+    # Upstream entries are untouched — this is the mirroring property that keeps
+    # `juliaup add release` working against a custom server.
+    @test db.channels["release"] == "1.12.7+0.x64.linux.gnu"
+    @test length(db.versions) == 5
+
+    # A channel may only point at a version the database knows about
+    @test_throws ErrorException Juliaup.add_channel!(db, "dangling", "9.9.9+0.x64.linux.gnu")
+end
+
+@testset "Database merging" begin
+
+    base = Juliaup.read_versiondb(FIXTURE)
+
+    overlay = VersionDB(Dict("1.12.7+app.x64.linux.gnu" => "assets/app.tar.gz"),
+                        Dict("app" => "1.12.7+app.x64.linux.gnu"),
+                        v"1.0.100")
+
+    merged = merge(base, overlay)
+
+    @test length(merged.versions) == 5
+    @test merged.channels["app"] == "1.12.7+app.x64.linux.gnu"
+    @test merged.channels["release"] == "1.12.7+0.x64.linux.gnu"
+
+    # The overlay wins on conflicts and carries the resulting database version
+    @test merged.dbversion == v"1.0.100"
+
+    conflicting = VersionDB(Dict{String, String}(),
+                            Dict("release" => "1.10.12+0.x64.linux.gnu"),
+                            v"1.0.100")
+    @test merge(base, conflicting).channels["release"] == "1.10.12+0.x64.linux.gnu"
+
+    # Merging leaves the operands alone
+    @test length(base.versions) == 4
+    @test base.channels["release"] == "1.12.7+0.x64.linux.gnu"
+end
+
+@testset "Database version bumping" begin
+
+    # juliaup ignores a published database whose number is not greater than the one compiled
+    # into the binary, and reports nothing when it does. Publishing must always go above upstream.
+    @test Juliaup.next_dbversion(v"1.0.92") > v"1.0.92"
+    @test Juliaup.next_dbversion(v"1.0.92") == v"1.0.93"
+    @test Juliaup.next_dbversion(v"1.0.92", v"1.0.124") == v"1.0.125"
+    @test Juliaup.next_dbversion(v"1.0.130", v"1.0.124") == v"1.0.131"
+
+    # Same major/minor line as upstream, otherwise the semver comparison stops being meaningful
+    @test Juliaup.next_dbversion(v"1.0.92").major == 1
+    @test Juliaup.next_dbversion(v"1.0.92").minor == 0
+end
+
+@testset "Publishing a distribution" begin
+
+    site = mktempdir()
+
+    dist = Juliaup.JuliaupDistribution(;
+        channel = "myapp-1.2.0",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        asset_base = "https://github.com/acme/myapp/releases/download/v1.2.0",
+        app_name = "myapp",
+        app_version = "1.2.0",
+        mirror = false,
+        dbversion = v"1.0.200")
+
+    Juliaup.publish(dist, site; assets = [(:linux, :x86_64), (:macos, :aarch64)])
+
+    # All four pointer files, all carrying the same number: juliaup's `dev` and
+    # `releasepreview` clients read their own file and 404 on a database we never wrote.
+    for name in DBVERSION_FILES
+        path = joinpath(site, "juliaup", name)
+        @test isfile(path)
+        @test strip(read(path, String)) == "1.0.200"
+    end
+    @test length(DBVERSION_FILES) == 4
+
+    # One database per target triple, and nothing else
+    dbdir = joinpath(site, "juliaup", "versiondb")
+    written = readdir(dbdir)
+    @test length(written) == 13
+    for target in JULIAUP_TARGETS
+        @test "versiondb-1.0.200-$target.json" in written
+    end
+
+    linux = Juliaup.read_versiondb(joinpath(dbdir, "versiondb-1.0.200-x86_64-unknown-linux-gnu.json"))
+    @test linux.dbversion == v"1.0.200"
+    @test haskey(linux.channels, "myapp-1.2.0")
+
+    fullversion = linux.channels["myapp-1.2.0"]
+    @test fullversion == "1.12.7+myapp-1x2x0.x64.linux.gnu"
+    @test linux.versions[fullversion] ==
+        "https://github.com/acme/myapp/releases/download/v1.2.0/myapp-1.2.0-linux-x86_64.tar.gz"
+
+    # An architecture alias, as upstream publishes alongside every channel
+    @test linux.channels["myapp-1.2.0~x64"] == fullversion
+
+    # The musl database is the one a stock Linux juliaup actually reads
+    musl = Juliaup.read_versiondb(joinpath(dbdir, "versiondb-1.0.200-x86_64-unknown-linux-musl.json"))
+    @test musl.channels == linux.channels
+    @test musl.versions == linux.versions
+
+    # macOS aarch64 lands only in the Apple Silicon database
+    darwin = Juliaup.read_versiondb(joinpath(dbdir, "versiondb-1.0.200-aarch64-apple-darwin.json"))
+    @test darwin.channels["myapp-1.2.0"] == "1.12.7+myapp-1x2x0.aarch64.apple.darwin14"
+    @test darwin.versions["1.12.7+myapp-1x2x0.aarch64.apple.darwin14"] ==
+        "https://github.com/acme/myapp/releases/download/v1.2.0/myapp-1.2.0-macos-aarch64.tar.gz"
+
+    intel = Juliaup.read_versiondb(joinpath(dbdir, "versiondb-1.0.200-x86_64-apple-darwin.json"))
+    @test !haskey(intel.channels, "myapp-1.2.0")
+
+    # Standalone mode carries our channels only
+    @test !haskey(linux.channels, "release")
+    @test length(linux.versions) == 1
+end
+
+@testset "Publishing on top of a mirrored database" begin
+
+    site = mktempdir()
+
+    dist = Juliaup.JuliaupDistribution(;
+        channel = "myapp",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        asset_base = "https://example.com/assets",
+        app_name = "myapp",
+        app_version = "1.2.0",
+        mirror = false,
+        dbversion = v"1.0.200")
+
+    upstream = Dict(target => Juliaup.read_versiondb(FIXTURE) for target in JULIAUP_TARGETS)
+
+    Juliaup.publish(dist, site; assets = [(:linux, :x86_64)], upstream)
+
+    db = Juliaup.read_versiondb(joinpath(site, "juliaup", "versiondb",
+                                         "versiondb-1.0.200-x86_64-unknown-linux-gnu.json"))
+
+    # Stock channels keep working next to ours — the whole point of mirroring
+    @test db.channels["release"] == "1.12.7+0.x64.linux.gnu"
+    @test db.channels["lts"] == "1.10.12+0.x64.linux.gnu"
+    @test db.channels["myapp"] == "1.12.7+myapp-1x2x0.x64.linux.gnu"
+    @test length(db.versions) == 5
+    @test db.dbversion == v"1.0.200"
+end
+
+@testset "Relative asset paths" begin
+
+    site = mktempdir()
+
+    # A site that also serves the tarballs keeps UrlPath relative, so the mirror can be
+    # moved to another host without rewriting the database (this is what JuliaHub does).
+    dist = Juliaup.JuliaupDistribution(;
+        channel = "myapp",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        asset_base = "assets",
+        app_name = "myapp",
+        app_version = "1.2.0",
+        mirror = false,
+        dbversion = v"1.0.200")
+
+    Juliaup.publish(dist, site; assets = [(:linux, :x86_64)])
+
+    db = Juliaup.read_versiondb(joinpath(site, "juliaup", "versiondb",
+                                         "versiondb-1.0.200-x86_64-unknown-linux-gnu.json"))
+
+    @test db.versions["1.12.7+myapp-1x2x0.x64.linux.gnu"] ==
+        "assets/myapp-1.2.0-linux-x86_64.tar.gz"
+end
+
+@testset "Client wrappers" begin
+
+    destination = mktempdir()
+
+    dist = Juliaup.JuliaupDistribution(;
+        channel = "myapp",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        server = "https://acme.github.io/myapp",
+        asset_base = "assets",
+        app_name = "myapp",
+        app_version = "1.2.0")
+
+    Juliaup.install_wrappers(dist, destination)
+
+    for name in ["myapp-juliaup", "myapp-julia", "myapp-juliaup.ps1", "myapp-julia.ps1"]
+        @test isfile(joinpath(destination, name))
+    end
+
+    juliaup = read(joinpath(destination, "myapp-juliaup"), String)
+
+    @test occursin("https://acme.github.io/myapp", juliaup)
+    @test occursin("JULIAUP_SERVER", juliaup)
+
+    # The depot is isolated so the user's stock juliaup installation is left alone
+    @test occursin("JULIAUP_DEPOT_PATH", juliaup)
+    @test occursin("juliaup-depots", juliaup)
+
+    if Sys.isunix()
+        @test (stat(joinpath(destination, "myapp-juliaup")).mode & 0o111) != 0
+    end
+
+    powershell = read(joinpath(destination, "myapp-juliaup.ps1"), String)
+    @test occursin("JULIAUP_SERVER", powershell)
+    @test occursin("https://acme.github.io/myapp", powershell)
+end
+
+@testset "Server URL validation" begin
+
+    # juliaup refuses a non-HTTPS server unless it is loopback, so a bad value should fail
+    # at publish time rather than silently on every user's machine.
+    @test_throws ErrorException Juliaup.JuliaupDistribution(;
+        channel = "myapp",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        server = "http://example.com",
+        asset_base = "assets",
+        app_name = "myapp",
+        app_version = "1.2.0")
+
+    # Loopback over plain HTTP is explicitly allowed by juliaup and is what the end to end
+    # test relies on
+    @test Juliaup.JuliaupDistribution(;
+        channel = "myapp",
+        julia_version = v"1.12.7",
+        build_tag = "myapp-1.2.0",
+        server = "http://127.0.0.1:8080",
+        asset_base = "assets",
+        app_name = "myapp",
+        app_version = "1.2.0") isa Juliaup.JuliaupDistribution
+end

--- a/test/juliaup_e2e.jl
+++ b/test/juliaup_e2e.jl
@@ -1,0 +1,227 @@
+# End to end check of the published layout against a real `juliaup` client.
+#
+# `juliaup` refuses a non-HTTPS server unless it is loopback, so a plain HTTP server bound to
+# 127.0.0.1 is enough to exercise the complete flow it performs for `juliaup add <channel>`:
+#
+#   GET /juliaup/RELEASECHANNELDBVERSION
+#   GET /juliaup/versiondb/versiondb-<dbversion>-<target>.json
+#   GET <UrlPath>
+#
+# Opt in with JULIA_RUN_JULIAUP_E2E=true; skipped when `juliaup` is not on PATH.
+
+import AppBundler
+import AppBundler.Juliaup
+import AppBundler.TarPack
+
+import Sockets
+import Tar
+import CodecZlib
+
+using Test
+
+const CONTENT_TYPES = Dict(".json" => "application/json",
+                           ".gz" => "application/gzip")
+
+function content_type(path)
+    return get(CONTENT_TYPES, last(splitext(path)), "application/octet-stream")
+end
+
+"""
+    serve(root) -> (port, stop)
+
+Minimal blocking HTTP/1.1 file server over loopback, serving `root`. Returns the bound port and
+a function that shuts the server down.
+"""
+function serve(root)
+
+    server = Sockets.listen(Sockets.localhost, 0)
+    port = Sockets.getsockname(server)[2]
+
+    task = @async begin
+        while isopen(server)
+            socket = try
+                Sockets.accept(server)
+            catch err
+                err isa Base.IOError || rethrow() # the listener was closed by `stop`
+                break
+            end
+
+            @async try
+                request = readline(socket)
+                while !isempty(strip(readline(socket))) end # discard headers
+
+                fields = split(request)
+                target = length(fields) > 1 ? fields[2] : "/"
+                path = joinpath(root, lstrip(first(split(target, '?')), '/'))
+
+                if isfile(path)
+                    body = read(path)
+                    write(socket, "HTTP/1.1 200 OK\r\n" *
+                          "Content-Type: $(content_type(path))\r\n" *
+                          "Content-Length: $(length(body))\r\n" *
+                          "Connection: close\r\n\r\n")
+                    write(socket, body)
+                else
+                    write(socket, "HTTP/1.1 404 Not Found\r\n" *
+                          "Content-Length: 0\r\nConnection: close\r\n\r\n")
+                end
+            catch err
+                # A client hanging up mid response is not a test failure, but anything else
+                # would otherwise be swallowed and surface as an unexplained timeout.
+                err isa Base.IOError || @error "Request handler failed" exception = err
+            finally
+                close(socket)
+            end
+        end
+    end
+
+    return port, () -> (close(server); wait(task))
+end
+
+"""
+Writes a stub distribution that answers the handful of calls juliaup makes against an
+installed Julia, and packs it the way the tarball target would.
+"""
+function stub_tarball(destination, root_name, version)
+
+    staging = mktempdir()
+    root = joinpath(staging, root_name)
+    mkpath(joinpath(root, "bin"))
+    mkpath(joinpath(root, "lib", "julia"))
+
+    write(joinpath(root, "bin", "julia"), """
+    #!/bin/sh
+    for arg in "\$@"; do
+      case "\$arg" in
+        -v|--version) echo "julia version $version"; exit 0 ;;
+      esac
+    done
+    printf '%s' "$version"
+    """)
+    chmod(joinpath(root, "bin", "julia"), 0o755)
+
+    write(joinpath(root, "lib", "julia", "sys.so"), "stub sysimage")
+
+    TarPack.pack(root, destination)
+
+    return destination
+end
+
+"""
+The target triple of the local juliaup binary, i.e. the one database it reads. Derived from the
+name juliaup gave its own cached copy rather than guessed from the host, since the Linux client is
+musl-static and reads the musl database even on a glibc system.
+"""
+function juliaup_target(depot = joinpath(homedir(), ".julia", "juliaup"))
+
+    for entry in readdir(depot)
+        captured = match(r"^versiondb-(.+)\.json$", entry)
+        isnothing(captured) || return captured[1]
+    end
+
+    error("Could not determine the local juliaup target triple from $depot")
+end
+
+"""
+Copy of a distribution under a different channel name, so one published site can carry several.
+"""
+function distribution_for(dist, channel)
+    return Juliaup.JuliaupDistribution(; channel,
+                                       julia_version = dist.julia_version,
+                                       build_tag = dist.build_tag,
+                                       server = dist.server,
+                                       asset_base = dist.asset_base,
+                                       app_name = dist.parameters["APP_NAME"],
+                                       app_version = dist.parameters["APP_VERSION"],
+                                       mirror = false)
+end
+
+if !Sys.isunix()
+    @info "Skipping juliaup end to end test: POSIX host required"
+elseif isnothing(Sys.which("juliaup"))
+    @info "Skipping juliaup end to end test: `juliaup` not found on PATH"
+else
+
+    site = mktempdir()
+    depot = mktempdir()
+
+    julia_version = v"1.12.7"
+    channel = "e2eapp-1.0.0"
+
+    mkpath(joinpath(site, "assets"))
+
+    port, stop = serve(site)
+    server = "http://127.0.0.1:$port"
+
+    try
+        os = :linux
+        arch = Sys.ARCH === :aarch64 ? :aarch64 : :x86_64
+
+        stub_tarball(joinpath(site, "assets", "e2eapp-1.0.0-$os-$arch.tar.gz"),
+                     "e2eapp-1.0.0", julia_version)
+
+        dist = Juliaup.JuliaupDistribution(;
+            channel,
+            julia_version,
+            build_tag = "e2eapp-1.0.0",
+            server,
+            asset_base = "assets",
+            app_name = "e2eapp",
+            app_version = "1.0.0",
+            mirror = false,
+            # Has to exceed the number compiled into the juliaup binary, otherwise the
+            # database is ignored and nothing at all is reported.
+            dbversion = v"99.0.0")
+
+        Juliaup.publish(dist, site; assets = [(os, arch)])
+
+        @testset "juliaup installs the published channel" begin
+
+            env = copy(ENV)
+            env["JULIAUP_SERVER"] = server
+            env["JULIAUP_DEPOT_PATH"] = depot
+
+            add = run(ignorestatus(setenv(`juliaup add $channel`, env)))
+            @test add.exitcode == 0
+
+            installed = joinpath(depot, "juliaup",
+                                 "julia-$(Juliaup.full_version_string(julia_version, "e2eapp-1.0.0", os, arch))")
+            @test isdir(installed)
+            @test isfile(joinpath(installed, "bin", "julia"))
+
+            status = read(setenv(`juliaup status`, env), String)
+            @test occursin(channel, status)
+        end
+
+        @testset "An absolute UrlPath escapes the server base" begin
+
+            # This is what makes the GitHub Pages layout work: the database is served from
+            # Pages while the tarballs stay on the releases page. juliaup resolves UrlPath
+            # with `Url::join`, so an absolute url replaces the base entirely and none of the
+            # tarball bytes pass through the host serving the database.
+            absolute = "$server/assets/e2eapp-1.0.0-$os-$arch.tar.gz"
+
+            elsewhere = distribution_for(dist, "e2eapp-absolute")
+
+            Juliaup.publish(elsewhere, site;
+                            assets = [(os, arch) => absolute],
+                            dbversion = v"99.0.1")
+
+            db = Juliaup.read_versiondb(joinpath(site, "juliaup", "versiondb",
+                                                 "versiondb-99.0.1-$(juliaup_target()).json"))
+            @test db.versions[db.channels["e2eapp-absolute"]] == absolute
+
+            env = copy(ENV)
+            env["JULIAUP_SERVER"] = server
+            env["JULIAUP_DEPOT_PATH"] = depot
+
+            add = run(ignorestatus(setenv(`juliaup add e2eapp-absolute`, env)))
+            @test add.exitcode == 0
+
+            status = read(setenv(`juliaup status`, env), String)
+            @test occursin("e2eapp-absolute", status)
+        end
+    finally
+        stop()
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,22 @@ end
     include("juliac.jl")
 end
 
+@time @safetestset "Tarball packing tests" begin
+    include("tarball.jl")
+end
+
+@time @safetestset "Juliaup version database tests" begin
+    include("juliaup.jl")
+end
+
 @time @safetestset "CLI API example" begin
     include("integrity.jl")
+end
+
+if get(ENV, "JULIA_RUN_JULIAUP_E2E", "false") == "true"
+    @time @safetestset "Juliaup end to end" begin
+        include("juliaup_e2e.jl")
+    end
 end
 
 if get(ENV, "JULIA_RUN_EXAMPLES", "false") == "true"

--- a/test/tarball.jl
+++ b/test/tarball.jl
@@ -1,0 +1,135 @@
+import AppBundler
+import AppBundler: Tarball, bundle, stage, TarPack
+
+import Tar
+import CodecZlib
+
+using Test
+
+"""
+Lists the archive entries the way `juliaup` sees them, i.e. after gzip decompression.
+"""
+function archive_entries(path)
+    entries = Tar.Header[]
+    open(path) do io
+        Tar.list(CodecZlib.GzipDecompressorStream(io)) do header
+            push!(entries, header)
+        end
+    end
+    return entries
+end
+
+"""
+Writes the shape of a staged Julia distribution, without actually building one.
+"""
+function fake_distribution(root)
+    mkpath(joinpath(root, "bin"))
+    mkpath(joinpath(root, "lib", "julia"))
+    mkpath(joinpath(root, "share", "julia", "stdlib", "v1.12"))
+
+    write(joinpath(root, "bin", "julia"), "#!/bin/sh\necho fake julia\n")
+    Sys.isunix() && chmod(joinpath(root, "bin", "julia"), 0o755)
+
+    write(joinpath(root, "lib", "julia", "sys.so"), "not really a sysimage")
+    write(joinpath(root, "share", "julia", "stdlib", "v1.12", "Project.toml"), "name = \"Stdlib\"\n")
+
+    return root
+end
+
+const APP = joinpath(pkgdir(AppBundler), "examples", "GtkApp")
+
+@testset "Tarball naming" begin
+
+    tarball = Tarball(APP; os = :linux, arch = :x86_64, compress = true)
+
+    @test AppBundler.suffix(tarball) == ".tar.gz"
+
+    # A tarball is produced for every operating system, so the archive name has to carry the
+    # OS. Without it a release matrix uploads three different archives under one asset name
+    # and the juliaup database can not tell them apart.
+    @test AppBundler.canonical_target_name(tarball) ==
+        "$(tarball.parameters["APP_NAME"])-$(tarball.parameters["APP_VERSION"])-linux-x86_64"
+
+    @test AppBundler.canonical_target_name(Tarball(APP; os = :macos, arch = :aarch64)) !=
+        AppBundler.canonical_target_name(Tarball(APP; os = :linux, arch = :aarch64))
+
+    @test AppBundler.suffix(Tarball(APP; os = :linux, compress = false)) == ""
+end
+
+@testset "Packing a distribution tree" begin
+
+    staging = mktempdir()
+    root = fake_distribution(joinpath(staging, "myapp-1.2.0"))
+
+    destination = joinpath(mktempdir(), "myapp-1.2.0-linux-x86_64.tar.gz")
+    TarPack.pack(root, destination)
+
+    @test isfile(destination)
+
+    entries = archive_entries(destination)
+    @test !isempty(entries)
+
+    # juliaup unpacks with `sans_parent(…, 1)`: exactly one leading component is stripped, so
+    # the archive must have a single root directory or the tree lands in the wrong place.
+    @test unique(first(splitpath(entry.path)) for entry in entries) == ["myapp-1.2.0"]
+
+    # After that strip, `resolve_julia_binary_path` looks for `<root>/bin/julia`
+    paths = [entry.path for entry in entries]
+    @test "myapp-1.2.0/bin/julia" in paths
+
+    julia = only(filter(e -> e.path == "myapp-1.2.0/bin/julia", entries))
+    @test julia.type == :file
+    @test julia.mode == 0o755   # the executable bit has to survive the round trip
+end
+
+@testset "Packing preserves symlinks" begin
+
+    staging = mktempdir()
+    root = fake_distribution(joinpath(staging, "myapp-1.2.0"))
+
+    # Julia distributions ship versioned shared libraries as symlinks
+    symlink("sys.so", joinpath(root, "lib", "julia", "sys.so.1"))
+
+    destination = joinpath(mktempdir(), "myapp.tar.gz")
+    TarPack.pack(root, destination)
+
+    link = only(filter(e -> e.path == "myapp-1.2.0/lib/julia/sys.so.1", archive_entries(destination)))
+
+    @test link.type == :symlink
+    @test link.link == "sys.so"
+end
+
+@testset "Packing rejects an ambiguous root" begin
+
+    staging = mktempdir()
+    root = fake_distribution(joinpath(staging, "myapp-1.2.0"))
+    mkpath(joinpath(staging, "stray"))
+
+    # Two roots would make juliaup's single strip produce a truncated tree
+    @test_throws ErrorException TarPack.pack(root, joinpath(mktempdir(), "bad.tar.gz"))
+end
+
+@testset "Bundled tarball is juliaup compatible" begin
+
+    tarball = Tarball(APP; os = :linux, arch = :x86_64, compress = true)
+
+    destination = joinpath(mktempdir(), "$(AppBundler.canonical_target_name(tarball)).tar.gz")
+
+    bundle(tarball, destination) do app_stage
+        fake_distribution(app_stage)
+    end
+
+    @test isfile(destination)
+
+    paths = [entry.path for entry in archive_entries(destination)]
+
+    # One root, named after the archive, with the interpreter directly under it
+    root = only(unique(first(splitpath(path)) for path in paths))
+    @test root == AppBundler.canonical_target_name(tarball)
+    @test "$root/bin/julia" in paths
+
+    # Refuses to clobber unless asked
+    @test_throws ErrorException bundle(identity, tarball, destination)
+    bundle(identity, tarball, destination; force = true)
+    @test isfile(destination)
+end


### PR DESCRIPTION
Closes #43.

## Relationship to #36

**This branch contains the three commits from #36 unchanged**, with @SimonDanisch as their author, because the juliaup work needs a tarball to install. Only the last commit is mine. If #36 lands first this rebases down to that single commit; if you would rather review the juliaup layer alone, I can rebase onto #36 and open this against that branch instead.

## What this adds

`juliaup` downloads from whatever host `JULIAUP_SERVER` points at, so distributing a bundled Julia through it needs no fork and no dedicated infrastructure — only a handful of static files, while the tarballs stay on the releases page. This is the approach JuliaHub uses for Dyad.

- **`AppBundler.Juliaup`** — writes the version database for all 13 client target triples plus the four `*DBVERSION` pointer files. Mirrors the upstream database by default so `release`, `lts` and every stock channel keep working for users pointed at your server; `--no-mirror` publishes your channels alone for an air-gapped site.
- **`appbundler juliaup <project_dir>`** — builds that static site, and `AppBundler.install_juliaup_workflow()` installs a GitHub Actions workflow that builds a tarball per platform, attaches them to the release, and deploys the database to GitHub Pages.
- **Client wrappers** — `<app>-juliaup` / `<app>-julia` plus PowerShell equivalents, setting `JULIAUP_SERVER` and isolating `JULIAUP_DEPOT_PATH` so a user's stock `juliaup` is untouched, as in the gist linked from the issue.
- **Docs** (`docs/src/juliaup.md`), a `CHANGELOG.md`, a `justfile`, and `llms.txt` / `llms-full.txt` generated with the documentation.

## Two silent failure modes, encoded with tests

Both cost real time to discover, so they are covered rather than documented alone:

- `juliaup` splits build metadata on `.` and reads the **second** component as the architecture. A build tag containing dots shifts that index and the entry resolves to a nonsense architecture. JuliaHub hit this — `1.11.8+dyad-2.1.0-rc3.x64.linux.gnu` parses its architecture as `1` — and later entries read `dyad-2x1x0-rc3`. AppBundler sanitises the tag.
- `juliaup` replaces its cached database only when the published number exceeds **both** the number compiled into its binary and its local copy, and **logs nothing** when it does not. The version is resolved above upstream automatically, and the workflow seeds the previously published number so republishing keeps climbing.

Also worth knowing: a database is named after the target triple of the **`juliaup` client**, not the Julia build. The Linux client is musl-static but runs on glibc hosts, so a Linux build must appear in both the `-musl` and `-gnu` databases (upstream publishes them as identical files), and each database carries every architecture its client can execute — including x86_64 in the Apple Silicon database, for Rosetta 2.

## Changes to the tarball target from #36

- **A tarball's canonical name now carries the OS** (`<app>-<version>-<os>-<arch>.tar.gz`). With `--target-os`, three runners otherwise upload three different archives under the same asset name and the database cannot tell them apart. This is a behaviour change to #36 and the one thing here I would most want a second opinion on.
- `TarPack.pack` reported `ArgumentError: Collection has multiple elements` instead of its own explanatory error — the `only()` threw before the guard ran.
- `--target-bundle=tarball` raised a `MethodError` with the `juliac` bundler; the missing `JuliaCBundle` method is added.

## Verification

`test/juliaup.jl` (132 assertions, fixture trimmed from the real upstream database, no network) and `test/tarball.jl` pass. Docs build warning-free.

`test/juliaup_e2e.jl` runs the whole flow against a **real `juliaup` client** over a loopback HTTP server — `juliaup` permits plain HTTP on loopback — covering both a relative and an absolute `UrlPath`. Opt in with `JULIA_RUN_JULIAUP_E2E=true`; it skips when `juliaup` is not on `PATH`. The absolute case is what makes the Pages-plus-releases layout work, so it is proven rather than assumed.

Manually, end to end:

```
appbundler build examples/CmdApp --target-bundle=tarball   # 197 MB tarball, single root, bin/julia
appbundler juliaup examples/CmdApp --build-dir=site ...    # 13 databases, 4 pointers, wrappers
juliaup add cmdapp-0.1.0                                   # installs
julia +cmdapp-0.1.0 -e 'import CmdApp'                     # the bundled package loads
```

Not verified here: a real GitHub Pages deploy and an HTTPS `juliaup add`. The workflow is reviewed by inspection; the loopback test exercises the same code path. `test/stage.jl` and `test/juliac.jl` fail in my environment for the pre-existing reasons CI works around (`xvfb-run`, `Pkg.Apps.add("JuliaC")`); with `juliac` installed, `test/integrity.jl` passes.

## Known limitation

A distribution installed through `juliaup` is launched as `julia`, not through the `bin/<app>` launcher the tarball also ships — and that launcher is what sets `USER_DATA`. Without it AppEnv falls back to a temporary depot on Linux, so packages a user adds on top of the distribution do not persist. Documented; setting `USER_DATA` restores persistence. Happy to address it differently if you would rather the juliaup path set it another way.

Assisted-by: AI
