### PR TITLE
feat: add AppImage bundle target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `appimage_depot` preference selecting where a Julia payload keeps its depot: `"app"` (default)
   points `USER_DATA` at `$XDG_DATA_HOME/<app>` and leaves the host `~/.julia` untouched, `"julia"`
   keeps the stock depot for sites where users expect their existing environments.
-- `appimage_compression` preference (`zstd` by default, `gzip` and `xz` also accepted).
+- `appimage_compression` preference: `zstd` by default, `gzip` the only alternative. The runtime
+  bundles squashfuse built against zstd and zlib alone, so `xz` and `lz4` images cannot be mounted
+  even though `mksquashfs` produces them; both are rejected at configuration time.
 - Documentation in `docs/src/appimage.md`, covering the format, the runtime, the depot choice, the
   build-time space requirement, and the FUSE requirement together with the no-FUSE workaround.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0]
+
+### Added
+
+- `AppImage` bundle format, producing a single mountable file rather than an installed tree
+  ([#42](https://github.com/PeaceFounder/AppBundler.jl/issues/42)). Because the payload is mounted
+  instead of unpacked, a bundled Julia distribution never writes its tens of thousands of files to
+  disk — the cost that makes other formats impractical on HPC filesystems.
+- `--target-bundle=appimage` command line option.
+- `AppBundler.AppImagePack`, with `pack`, `offset` and `unpack`. `unpack` reads the squashfs payload
+  directly, which is the fallback for machines without a usable FUSE.
+- `AppBundler.AppImageRuntime`, resolving the runtime binary from an explicit path, the
+  `appimage_runtime` preference, or `AppImageRuntime_jll` once that package is registered.
+- `appimage_depot` preference selecting where a Julia payload keeps its depot: `"app"` (default)
+  points `USER_DATA` at `$XDG_DATA_HOME/<app>` and leaves the host `~/.julia` untouched, `"julia"`
+  keeps the stock depot for sites where users expect their existing environments.
+- `appimage_compression` preference (`zstd` by default, `gzip` and `xz` also accepted).
+- Documentation in `docs/src/appimage.md`, covering the format, the runtime, the depot choice, the
+  build-time space requirement, and the FUSE requirement together with the no-FUSE workaround.
+
+### Changed
+
+- `bundle(::Function, ::MSIX, ::String)` now has a docstring; it was empty and rendered blank in
+  the manual.
+
+## [1.0.1]
+
+Releases up to and including 1.0.1 predate this changelog; see the
+[commit history](https://github.com/PeaceFounder/AppBundler.jl/commits/main) for details.
+
+[Unreleased]: https://github.com/PeaceFounder/AppBundler.jl/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/PeaceFounder/AppBundler.jl/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.com/PeaceFounder/AppBundler.jl/releases/tag/v1.0.1

--- a/LocalPreferences.toml
+++ b/LocalPreferences.toml
@@ -29,3 +29,11 @@ juliaimg_sysimg = []
 juliaimg_selective_assets = false
 
 juliac_trim = false
+
+# AppImage. `appimage_depot` selects where a Julia payload keeps its depot: "app" points USER_DATA
+# at $XDG_DATA_HOME/<app>, leaving the host ~/.julia untouched; "julia" keeps the stock depot.
+# `appimage_runtime` points at an AppImage runtime; leave empty to use AppImageRuntime_jll once it
+# is registered.
+appimage_depot = "app"
+appimage_compression = "zstd"
+appimage_runtime = ""

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AppBundler"
 uuid = "40eb83ae-c93a-480c-8f39-f018b568f472"
-version = "1.0.1"
+version = "1.1.0"
 authors = ["Janis Erdmanis <janiserdmanis@protonmail.ch>"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -37,6 +37,7 @@ makedocs(
         "Overview" => "index.md",
         "Customization" => "customization.md",
         "Deployment" => "deployment.md", # codesigning, GitHub CI,
+        "AppImage" => "appimage.md",
         "Troubleshooting" => "troubleshooting.md",
         "Reference" => "reference.md" # Here I could also give an overview of the internal API on how it composes. Perhaps I shall madke that as documentation for the module here.
     ]

--- a/docs/src/appimage.md
+++ b/docs/src/appimage.md
@@ -37,10 +37,12 @@ usr/share/metainfo/<id>.appdata.xml             AppStream metadata
 bin/ lib/ share/ etc/                           the Julia distribution
 ```
 
-The payload is compressed with **zstd** by default. `gzip` and `xz` also work — the runtime links
-squashfuse against zstd and zlib, and squashfuse handles xz — but zstd decompresses far faster,
-which is the point of mounting in the first place. `lz4` is deliberately rejected: `mksquashfs`
-offers it, and the runtime cannot read it.
+The payload is compressed with **zstd** by default, and `gzip` is the only other choice. The
+runtime bundles squashfuse built against zstd and zlib alone, so an image compressed any other way
+cannot be mounted — `mksquashfs` happily produces `xz` and `lz4` images, and the runtime answers
+`Failed to extract AppImage` for both. AppBundler therefore rejects them at configuration time
+rather than letting you ship an AppImage nobody can run. Of the two that work, zstd decompresses
+far faster, which is the point of mounting rather than unpacking.
 
 ## Obtaining the runtime
 

--- a/docs/src/appimage.md
+++ b/docs/src/appimage.md
@@ -1,0 +1,128 @@
+# AppImage
+
+An AppImage is a single executable file that is **mounted** rather than installed. For a Julia
+application this matters more than it might seem: a bundled distribution is tens of thousands of
+small files, and writing all of them onto a network filesystem is the slow part of every other
+format. On HPC clusters that cost — sometimes called the hydration problem — is what stops people
+distributing Julia applications as archives at all. An AppImage never unpacks, so it does not pay it.
+
+```
+appbundler build . --target-bundle=appimage --build-dir=build
+```
+
+produces `build/<app>-<version>-<arch>.AppImage`, which a user makes executable and runs. There is
+nothing to install and nothing to clean up afterwards.
+
+## How the format works
+
+An AppImage is a **runtime ELF followed by a squashfs image**. The runtime knows the filesystem
+begins immediately after itself, mounts it through FUSE, and executes `AppRun` from the mount
+point. That is the whole format — there is no container, no manifest, and no package database.
+
+AppBundler stages an AppDir, then has `mksquashfs` write the filesystem straight into the output
+file after a reserved prefix, and finally writes the runtime into that prefix. Building the
+squashfs separately and concatenating would need a second full-size temporary copy, which for a
+Julia distribution is hundreds of megabytes.
+
+The staged AppDir looks like this:
+
+```
+AppRun                                          entry point, execs bin/julia
+<app>.desktop                                   Icon=<app>, no path, no extension
+<app>.png
+.DirIcon                                        what file managers read for the thumbnail
+usr/share/applications/<app>.desktop            menu integration once installed
+usr/share/icons/hicolor/256x256/apps/<app>.png
+usr/share/metainfo/<id>.appdata.xml             AppStream metadata
+bin/ lib/ share/ etc/                           the Julia distribution
+```
+
+The payload is compressed with **zstd** by default. `gzip` and `xz` also work — the runtime links
+squashfuse against zstd and zlib, and squashfuse handles xz — but zstd decompresses far faster,
+which is the point of mounting in the first place. `lz4` is deliberately rejected: `mksquashfs`
+offers it, and the runtime cannot read it.
+
+## Obtaining the runtime
+
+The runtime is a ~900 KB static binary. There is no jll for it yet — packaging one means first
+packaging `libfuse` and `squashfuse`, neither of which exists in Yggdrasil — so for now point
+AppBundler at a runtime you obtained yourself:
+
+```toml
+# LocalPreferences.toml
+[AppBundler]
+appimage_runtime = "/path/to/runtime-x86_64"
+```
+
+or pass it directly:
+
+```julia
+AppImage(app_dir; runtime = "/path/to/runtime-x86_64")
+```
+
+Signed runtimes are published at
+[AppImage/type2-runtime](https://github.com/AppImage/type2-runtime/releases). Prefer a dated tag
+over `continuous` so your builds stay reproducible.
+
+Once `AppImageRuntime_jll` is registered, leaving `appimage_runtime` empty will pick it up
+automatically. Note that a jll provides the artifact for the host platform, so building an AppImage
+for another architecture still needs an explicit path.
+
+## Build-time disk space
+
+The AppDir is staged uncompressed before it is packed, so building an AppImage of a Julia
+distribution needs a couple of gigabytes of working space. Julia stages into `TMPDIR`, which on
+many systems is a `tmpfs` sized well below that, and `mksquashfs` reports exhaustion only as
+`FATAL ERROR: Probably out of space on output filesystem`. If you hit that, point `TMPDIR` at a
+real filesystem:
+
+```
+TMPDIR=/var/tmp appbundler build . --target-bundle=appimage --build-dir=build
+```
+
+## Where the depot goes
+
+The mounted filesystem is read-only and disappears when the application exits, so the Julia depot
+has to live somewhere else. Two options, selected with the `appimage_depot` preference:
+
+- **`"app"`** (default) — `AppRun` points `USER_DATA` at `$XDG_DATA_HOME/<app>`, falling back to
+  `~/.local/share/<app>`. The application gets a persistent per-user depot and the host's `~/.julia`
+  is never touched.
+- **`"julia"`** — the stock depot is left as Julia found it, with the bundled `share/julia`
+  appended so the shipped packages stay resolvable. Choose this where users expect the application
+  to see the environments they already have, which is common on HPC.
+
+## FUSE
+
+Mounting needs `fusermount` on the machine running the AppImage. Where it is missing the runtime
+says so and suggests `--appimage-extract-and-run`, which extracts to a temporary directory first —
+correct, but it gives up the property that made the format attractive.
+
+If your target machines lack FUSE, the payload can be read directly, since it is an ordinary
+squashfs at a known offset:
+
+```julia
+using AppBundler
+AppBundler.AppImagePack.unpack("MyApp-1.0.0-x86_64.AppImage", "extracted/")
+```
+
+or, outside Julia:
+
+```
+unsquashfs -o $(./MyApp-1.0.0-x86_64.AppImage --appimage-offset) -d extracted MyApp-1.0.0-x86_64.AppImage
+```
+
+`--appimage-offset` and `AppBundler.AppImagePack.offset` return the same number: the size of the
+runtime prefix.
+
+## API
+
+```@docs
+AppBundler.AppImagePack
+AppBundler.AppImagePack.pack
+AppBundler.AppImagePack.offset
+AppBundler.AppImagePack.unpack
+AppBundler.AppImageRuntime
+AppBundler.AppImageRuntime.resolve
+AppBundler.bundle(::AppBundler.JuliaImgBundle, ::AppBundler.AppImage, ::String)
+```

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -21,13 +21,16 @@ Both specs can be staged directly into a directory for inspection before packagi
 
 ## Bundle Formats
 
-A bundle format defines the packaging target. The three supported formats are `DMG` (macOS), `MSIX` (Windows), and `Snap` (Linux). They are instantiated from a project directory:
+A bundle format defines the packaging target. The supported formats are `DMG` (macOS), `MSIX` (Windows), and `Snap` and `AppImage` (Linux). They are instantiated from a project directory:
 
 ```julia
-dmg  = DMG(project; arch = Sys.ARCH, kwargs...)
-msix = MSIX(project; arch = Sys.ARCH, kwargs...)
-snap = Snap(project; arch = Sys.ARCH, kwargs...)
+dmg      = DMG(project; arch = Sys.ARCH, kwargs...)
+msix     = MSIX(project; arch = Sys.ARCH, kwargs...)
+snap     = Snap(project; arch = Sys.ARCH, kwargs...)
+appimage = AppImage(project; arch = Sys.ARCH, kwargs...)
 ```
+
+`AppImage` produces a single mountable file rather than an installed tree; see [AppImage](@ref).
 
 Each format reads configuration file overrides from the corresponding `project/meta/<format>` directory and carries architecture information that determines the destination platform. Bundle formats can also be staged independently via `stage(format, destination)` to produce the directory structure before compression and signing.
 
@@ -51,6 +54,7 @@ AppBundler.JuliaCBundle
 AppBundler.DMG
 AppBundler.MSIX
 AppBundler.Snap
+AppBundler.AppImage
 ```
 
 ## Functions
@@ -60,5 +64,7 @@ AppBundler.stage(::AppBundler.JuliaImg.JuliaImgBundle, ::String)
 AppBundler.stage(::AppBundler.JuliaC.JuliaCBundle, ::String)
 AppBundler.stage(::AppBundler.MSIX, ::String)
 AppBundler.bundle(::Function, ::AppBundler.DMG, ::String)
+AppBundler.bundle(::Function, ::AppBundler.MSIX, ::String)
+AppBundler.bundle(::AppBundler.JuliaC.JuliaCBundle, ::AppBundler.AppImage, ::String)
 AppBundler.bundle(::AppBundler.JuliaImgBundle, ::AppBundler.DMG, ::String)
 ```

--- a/justfile
+++ b/justfile
@@ -1,0 +1,39 @@
+# Main entry points for AppBundler development.
+# Run `just` to list them.
+
+julia := "julia --startup-file=no"
+
+default:
+    @just --list
+
+# Install dependencies, including the Python `ds_store` module via Conda
+instantiate:
+    {{julia}} --project=. -e 'using Pkg; Pkg.instantiate()'
+    {{julia}} --project=. deps/build.jl
+
+# Run the test suite
+test:
+    {{julia}} --project=. -e 'using Pkg; Pkg.test()'
+
+# Run the AppImage tests alone
+test-appimage:
+    {{julia}} --project=. test/appimage.jl
+
+# Run the AppImage end to end test against a real runtime
+# APPIMAGE_RUNTIME must point at a runtime from
+# https://github.com/AppImage/type2-runtime/releases
+test-appimage-e2e:
+    {{julia}} --project=. test/appimage_e2e.jl
+
+# Build the documentation
+docs:
+    {{julia}} --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path = pwd())); Pkg.instantiate()'
+    {{julia}} --project=docs docs/make.jl
+
+# Build an AppImage from an example app
+appimage app="examples/CmdApp":
+    {{julia}} --project=. -m AppBundler build {{app}} --build-dir=build --target-bundle=appimage --force
+
+# Remove build outputs
+clean:
+    rm -rf build docs/build

--- a/recipes/appimage/AppRun.sh
+++ b/recipes/appimage/AppRun.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Generic entry point for a non-Julia payload.
+
+if [ -z "${APPDIR}" ]; then
+    APPDIR=$(cd -P "$(dirname "$(readlink -f "$0")")" >/dev/null 2>&1 && pwd)
+fi
+
+exec "${APPDIR}/bin/{{APP_NAME}}" "$@"

--- a/recipes/appimage/juliaimg_AppRun.sh
+++ b/recipes/appimage/juliaimg_AppRun.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Entry point the AppImage runtime executes after mounting the bundled filesystem.
+#
+# $APPDIR is set by the runtime and points at the mount point. It is absent when the AppDir is
+# executed directly (during a build, or after --appimage-extract), so fall back to resolving it
+# from this script's own location.
+
+if [ -z "${APPDIR}" ]; then
+    APPDIR=$(cd -P "$(dirname "$(readlink -f "$0")")" >/dev/null 2>&1 && pwd)
+fi
+
+{{#APP_DEPOT}}
+# Persist the depot under a per-user directory rather than the mount point, which is read-only and
+# disappears when the AppImage exits. AppEnv reads USER_DATA in startup.jl to place the depot.
+if [ -z "${USER_DATA}" ]; then
+    export USER_DATA="${XDG_DATA_HOME:-${HOME}/.local/share}/{{APP_NAME}}"
+fi
+{{/APP_DEPOT}}
+
+exec "${APPDIR}/bin/julia" {{#MODULE_NAME}}--eval="using {{MODULE_NAME}}" -- {{/MODULE_NAME}}"$@"

--- a/recipes/appimage/main.desktop
+++ b/recipes/appimage/main.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name={{APP_DISPLAY_NAME}}
+Exec={{APP_NAME}}
+Icon={{APP_NAME}}
+Version={{APP_VERSION}}
+Comment={{APP_SUMMARY}}
+Terminal={{#WINDOWED}}false{{/WINDOWED}}{{^WINDOWED}}true{{/WINDOWED}}
+Type=Application
+Categories=Utility;

--- a/recipes/appimage/metainfo.xml
+++ b/recipes/appimage/metainfo.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>{{BUNDLE_IDENTIFIER}}</id>
+  <name>{{APP_DISPLAY_NAME}}</name>
+  <summary>{{APP_SUMMARY}}</summary>
+  <description>
+    <p>{{APP_DESCRIPTION}}</p>
+  </description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+  <developer_name>{{PUBLISHER_DISPLAY_NAME}}</developer_name>
+  <launchable type="desktop-id">{{APP_NAME}}.desktop</launchable>
+  <releases>
+    <release version="{{APP_VERSION}}"/>
+  </releases>
+</component>

--- a/recipes/appimage/startup.jl
+++ b/recipes/appimage/startup.jl
@@ -1,0 +1,31 @@
+# Startup file used when `appimage_depot = "julia"`.
+#
+# The stock startup.jl calls AppEnv.init(), which replaces DEPOT_PATH outright — every
+# set_depot_path_* in AppEnv begins with `empty!(DEPOT_PATH)`. For sites that want the user's real
+# ~/.julia depot, set up the load path for the bundled stdlib but leave the depot as Julia found
+# it, appending the bundled share/julia so the shipped packages stay resolvable.
+
+if isdir(joinpath(last(DEPOT_PATH), "compiled/v$(VERSION.major).$(VERSION.minor)", "AppEnv")) || any(i -> i.name == "AppEnv", keys(Base.loaded_modules))
+    import AppEnv
+else
+    include(joinpath(Sys.STDLIB, "AppEnv/src/AppEnv.jl"))
+end
+
+let config_path = joinpath(dirname(Sys.BINDIR), "config"),
+    index_path = joinpath(dirname(Sys.BINDIR), "index")
+
+    (; stdlib_project_name) = AppEnv.load_config(config_path)
+
+    AppEnv.set_load_path!(Base.LOAD_PATH; stdlib_project_name)
+
+    bundled_depot = joinpath(dirname(Sys.BINDIR), "share/julia")
+    bundled_depot in Base.DEPOT_PATH || push!(Base.DEPOT_PATH, bundled_depot)
+
+    isfile(index_path) && AppEnv.load_pkgorigins!(Base.pkgorigins, index_path)
+end
+
+if isinteractive() && !isempty("{{MODULE_NAME}}") && isempty(ARGS)
+    println("No arguments provided. To display help, use:")
+    julia = relpath(joinpath(Sys.BINDIR, "julia"), pwd())
+    println("  $julia --eval \"using {{MODULE_NAME}}\" --help")
+end

--- a/src/AppBundler.jl
+++ b/src/AppBundler.jl
@@ -29,6 +29,9 @@ include("DMG/DMGPack.jl")
 
 include("Snap/SnapPack.jl")
 
+include("AppImage/AppImagePack.jl")
+include("AppImage/Runtime.jl")
+
 include("MSIX/MSIXPack.jl")
 include("MSIX/MSIXIcons.jl")
 include("MSIX/WinSubsystem.jl")
@@ -64,7 +67,7 @@ end
 #@doc (@doc JuliaImg.JuliaImgBundle) JuliaImgBundle
 #@doc (@doc JuliaC.JuliaCBundle) JuliaCBundle
 
-export JuliaImgBundle, JuliaCBundle, DMG, MSIX, Snap, bundle, stage
+export JuliaImgBundle, JuliaCBundle, DMG, MSIX, Snap, AppImage, bundle, stage
 export main 
 
 

--- a/src/AppImage/AppImagePack.jl
+++ b/src/AppImage/AppImagePack.jl
@@ -19,11 +19,13 @@ import squashfs_tools_jll: mksquashfs, unsquashfs
 """
 Compressors accepted for the squashfs payload.
 
-The runtime links squashfuse against zstd and zlib only, so `lz4` — which `mksquashfs` itself
-offers — would produce an image the runtime cannot mount. `xz` works because squashfuse handles it,
-but decompresses far more slowly, which is the wrong trade for the HPC case this format targets.
+The runtime bundles squashfuse built against zstd and zlib only, so anything else produces an image
+it cannot mount. `mksquashfs` also offers `xz` and `lz4`; both are rejected here, verified against
+the upstream runtime, which reports `Failed to extract AppImage` for an xz payload. Between the two
+that remain, zstd decompresses far faster than gzip, which is the point of mounting rather than
+unpacking.
 """
-const COMPRESSORS = [:zstd, :gzip, :xz]
+const COMPRESSORS = [:zstd, :gzip]
 
 """
     pack(appdir::String, destination::String, runtime::String; compression = :zstd)

--- a/src/AppImage/AppImagePack.jl
+++ b/src/AppImage/AppImagePack.jl
@@ -1,0 +1,117 @@
+"""
+    AppImagePack
+
+Assembly of an AppImage from a staged AppDir.
+
+An AppImage is nothing more than a **runtime ELF followed by a squashfs image**. The runtime knows
+where the filesystem begins because it is appended immediately after itself, mounts it through FUSE,
+and executes `AppRun` from the mount point. Nothing is written to disk, which is why AppImages suit
+HPC: a Julia distribution is tens of thousands of small files, and unpacking one onto a network
+filesystem is exactly the cost this format avoids.
+
+The runtime carries the magic bytes `AI\\x02` at offset 8 already, so assembly is a concatenation
+with no patching.
+"""
+module AppImagePack
+
+import squashfs_tools_jll: mksquashfs, unsquashfs
+
+"""
+Compressors accepted for the squashfs payload.
+
+The runtime links squashfuse against zstd and zlib only, so `lz4` — which `mksquashfs` itself
+offers — would produce an image the runtime cannot mount. `xz` works because squashfuse handles it,
+but decompresses far more slowly, which is the wrong trade for the HPC case this format targets.
+"""
+const COMPRESSORS = [:zstd, :gzip, :xz]
+
+"""
+    pack(appdir::String, destination::String, runtime::String; compression = :zstd)
+
+Compress `appdir` into a squashfs image placed after `runtime`, producing an executable AppImage at
+`destination`.
+"""
+function pack(appdir::String, destination::String, runtime::String; compression::Symbol = :zstd)
+
+    compression in COMPRESSORS ||
+        error("`$compression` is not a supported AppImage compressor. Choose one of: " *
+              join(COMPRESSORS, ", ") * ".")
+
+    isfile(runtime) || error("The AppImage runtime `$runtime` does not exist")
+
+    isfile(joinpath(appdir, "AppRun")) ||
+        error("`$appdir` has no AppRun; the runtime executes it after mounting and refuses to " *
+              "start without it.")
+
+    mkpath(dirname(destination))
+
+    prefix = filesize(runtime)
+
+    # `-offset` reserves room for the runtime so the filesystem is written straight into the final
+    # file. Building the squashfs separately and concatenating would need a second full-size
+    # temporary copy, which for a Julia distribution is hundreds of megabytes — usually landing in
+    # /tmp, and on a machine with a small tmpfs that fails as an opaque "out of space".
+    #
+    # -root-owned keeps the build user out of the image, -noappend makes the build reproducible
+    # when the destination already exists.
+    run(`$(mksquashfs()) $appdir $destination -root-owned -noappend -comp $compression -b 128K -offset $prefix`)
+
+    # mksquashfs zeroes the bytes it skipped rather than preserving them, so the runtime goes in
+    # afterwards, over the reserved prefix.
+    open(destination, "r+") do file
+        seekstart(file)
+        write(file, read(runtime))
+    end
+
+    Sys.isunix() && chmod(destination, 0o755)
+
+    return destination
+end
+
+"""
+    offset(path::String) -> Int
+
+Byte offset at which the squashfs payload begins, i.e. the size of the runtime prefix. This is the
+number `<app>.AppImage --appimage-offset` reports, and what `unsquashfs -o` needs.
+"""
+function offset(path::String)
+
+    # The payload begins where the ELF ends, and an ELF ends after its section header table. This
+    # is how the runtime itself answers `--appimage-offset`.
+    #
+    # Scanning for the squashfs magic instead would be wrong: the runtime embeds squashfuse, whose
+    # own "hsqs" constant appears hundreds of kilobytes before the real payload.
+    header = open(path) do file
+        read(file, 64)
+    end
+
+    length(header) >= 64 && header[1:4] == UInt8[0x7f, 0x45, 0x4c, 0x46] ||
+        error("`$path` does not start with an ELF header, so it is not an AppImage.")
+
+    little_endian(bytes) = foldr((byte, acc) -> acc << 8 | byte, bytes; init = UInt64(0))
+
+    if header[5] == 0x02 # 64 bit
+        shoff, shentsize, shnum = little_endian(header[41:48]), little_endian(header[59:60]), little_endian(header[61:62])
+    else                 # 32 bit
+        shoff, shentsize, shnum = little_endian(header[33:36]), little_endian(header[47:48]), little_endian(header[49:50])
+    end
+
+    return Int(shoff + shentsize * shnum)
+end
+
+"""
+    unpack(source::String, destination::String)
+
+Extract the payload of an AppImage without mounting it.
+
+This is the fallback for a machine with no usable FUSE — the AppImage's own
+`--appimage-extract` needs to run the runtime, which is precisely what fails there.
+"""
+function unpack(source::String, destination::String)
+
+    run(`$(unsquashfs()) -f -o $(offset(source)) -d $destination $source`)
+
+    return destination
+end
+
+end

--- a/src/AppImage/Runtime.jl
+++ b/src/AppImage/Runtime.jl
@@ -1,0 +1,91 @@
+"""
+    AppImageRuntime
+
+Resolution of the AppImage runtime binary.
+
+The runtime is a ~900 KB static-PIE ELF that mounts the appended squashfs and executes `AppRun`.
+Unlike every other binary AppBundler depends on there is no jll for it yet: building one means
+first packaging `libfuse` and `squashfuse`, neither of which exists in Yggdrasil. Until
+`AppImageRuntime_jll` is registered, point AppBundler at a runtime you obtained yourself.
+"""
+module AppImageRuntime
+
+"""
+Architectures the upstream project publishes a runtime for.
+"""
+const ARCHITECTURES = [:x86_64, :i686, :aarch64, :armhf]
+
+const RELEASES = "https://github.com/AppImage/type2-runtime/releases"
+
+"""
+    resolve(arch::Symbol; runtime = nothing, allow_jll = true) -> String
+
+Return the path of the AppImage runtime for `arch`.
+
+An explicit `runtime` path wins. Otherwise `AppImageRuntime_jll` is used when the user has it
+installed — it is looked up with a guarded import rather than declared as a dependency, since the
+package is not registered yet. Failing both, an error explains how to supply one.
+"""
+function resolve(arch::Symbol; runtime::Union{String, Nothing} = nothing, allow_jll::Bool = true)
+
+    if !isnothing(runtime) && !isempty(runtime)
+        isfile(runtime) ||
+            error("The AppImage runtime `$runtime` does not exist. Set `appimage_runtime` in " *
+                  "LocalPreferences.toml, or pass `runtime = <path>` to `AppImage`.")
+        return runtime
+    end
+
+    if allow_jll
+        from_jll = jll_runtime(arch)
+        isnothing(from_jll) || return from_jll
+    end
+
+    arch in ARCHITECTURES ||
+        error("No AppImage runtime exists for `$arch`. Upstream publishes: " *
+              join(ARCHITECTURES, ", ") * ".")
+
+    error("""
+          No AppImage runtime available for $arch.
+
+          AppBundler uses `AppImageRuntime_jll` when it is installed. That package is not yet
+          registered, so until it is, obtain a runtime and point AppBundler at it:
+
+              # LocalPreferences.toml
+              [AppBundler]
+              appimage_runtime = "/path/to/runtime-$arch"
+
+          or pass `runtime = "/path/to/runtime-$arch"` to `AppImage`. Upstream publishes signed
+          runtimes at $RELEASES — prefer a dated tag over `continuous` so builds stay reproducible.
+          """)
+end
+
+"""
+    jll_runtime(arch::Symbol) -> Union{String, Nothing}
+
+Look for `AppImageRuntime_jll` in the active environment, returning `nothing` when it is absent.
+
+The package is resolved by name through the active environment rather than by UUID, because it is
+not registered yet and its UUID is therefore not knowable here. Once it is registered this starts
+working with no change.
+
+A jll provides the artifact for the *host* platform, so it only answers for a native build.
+Bundling for another architecture still needs an explicit runtime path.
+"""
+function jll_runtime(arch::Symbol)
+
+    arch === Sys.ARCH || return nothing
+
+    return try
+        pkgid = Base.identify_package("AppImageRuntime_jll")
+        isnothing(pkgid) && return nothing
+
+        jll = Base.require(pkgid)
+        path = Base.invokelatest(getproperty, jll, :runtime_path)
+
+        isfile(path) ? path : nothing
+    catch
+        nothing
+    end
+end
+
+end

--- a/src/bundle.jl
+++ b/src/bundle.jl
@@ -547,6 +547,12 @@ function bundle(setup::Function, dmg::DMG, destination::String; force = false, p
 end
 
 """
+    bundle(setup::Function, msix::MSIX, destination::String; force = false, password = "")
+
+MSIX variant of [`bundle(setup, config, destination)`](@ref).
+
+Before packing, the staging area is checked against the constraints Windows places on an app
+package — path length, symlinks and non-ASCII paths — according to the `MSIX` configuration.
 """
 function bundle(setup::Function, msix::MSIX, destination::String; force = false, password = "")
 
@@ -602,6 +608,169 @@ function bundle(setup::Function, snap::Snap, destination::String; force = false)
     if snap.compress
         @info "Packaging staging area into Snap..."
         SnapPack.pack(app_stage, destination)
+    end
+
+    return
+end
+
+
+"""
+    AppImage([overlay]; arch, compress, compression, depot, runtime, kwargs...)
+
+Create an AppImage configuration object for Linux application packaging.
+
+An AppImage is a runtime ELF followed by a squashfs image. The runtime **mounts** that filesystem
+rather than extracting it, so a bundled Julia distribution — tens of thousands of small files —
+never lands on disk. That is what makes the format worth having on HPC, where unpacking a tarball
+onto a network filesystem is the expensive part.
+
+Mounting requires `fusermount` on the target machine. Where it is missing the runtime falls back to
+`--appimage-extract-and-run`, and [`AppBundler.AppImagePack.unpack`](@ref) reads the payload without
+running the runtime at all.
+
+# Arguments
+- `overlay`: Path to a project directory containing `Project.toml`, optional `LocalPreferences.toml`, and optional `meta/appimage/` overrides
+
+# Keyword Arguments
+- `prefix = joinpath(dirname(@__DIR__), "recipes")`: Base directory or array of directories to search for configuration files in sequential order
+- `icon = get_path(prefix, ["appimage/icon.png", "icon.png"])`: Path to application icon file
+- `desktop_launcher = get_path(prefix, "appimage/main.desktop")`: Path to the desktop entry template
+- `metainfo = get_path(prefix, "appimage/metainfo.xml")`: Path to the AppStream metadata template
+- `main_launcher`: Path to the `AppRun` template; resolved from prefix using the bundler predicate
+- `startup_file = get_path(prefix, "appimage/startup.jl")`: Startup file used when `depot = "julia"`, which sets up the load path without replacing `DEPOT_PATH`
+- `depot`: Where a Julia payload keeps its depot. `"app"` (default) points `USER_DATA` at
+  `\$XDG_DATA_HOME/<app>`, giving a persistent per-user depot that leaves the host `~/.julia`
+  untouched; `"julia"` keeps the stock depot; defaults to the `appimage_depot` preference
+- `compression`: squashfs compressor, one of `:zstd` (default), `:gzip` or `:xz`; defaults to the
+  `appimage_compression` preference
+- `runtime`: Path to the AppImage runtime. When unset, `AppImageRuntime_jll` is used if installed;
+  defaults to the `appimage_runtime` preference
+- `windowed`: If `true`, the application runs without a console window; defaults to `windowed` preference
+- `compress`: If `true`, pack the AppDir into an `.AppImage`; defaults to `compress` preference
+- `arch = Sys.ARCH`: Target CPU architecture
+- `predicate`: Bundler predicate used for hook selection; defaults to `bundler` preference
+- `parameters`: Dictionary of parameters for Mustache template rendering. When `overlay` is provided, pre-populated from `Project.toml` and preferences
+
+# Examples
+```julia
+AppImage(app_dir)
+AppImage(app_dir; depot = "julia")                       # keep the stock ~/.julia depot
+AppImage(app_dir; runtime = "/path/to/runtime-x86_64")   # until AppImageRuntime_jll exists
+```
+"""
+struct AppImage
+    icon::String
+    desktop_launcher::String
+    metainfo::String
+    main_launcher::Union{String, Nothing}
+    startup_file::Union{String, Nothing}
+    depot::String
+    compression::Symbol
+    runtime::Union{String, Nothing}
+    windowed::Bool
+    compress::Bool
+    arch::Symbol
+    predicate::String
+    parameters::Dict{String, Any}
+end
+
+const APPIMAGE_DEPOTS = ["app", "julia"]
+
+function AppImage(;
+                  prefix = joinpath(dirname(@__DIR__), "recipes"),
+                  preferences = preferences(),
+                  predicate = preferences["bundler"],
+                  icon = get_path(prefix, ["appimage/icon.png", "icon.png"]),
+                  desktop_launcher = get_path(prefix, "appimage/main.desktop"),
+                  metainfo = get_path(prefix, "appimage/metainfo.xml"),
+                  main_launcher = get_path(prefix, hook("appimage/AppRun.sh", predicate); warn = false),
+                  startup_file = get_path(prefix, "appimage/startup.jl"; warn = false),
+                  depot = get(preferences, "appimage_depot", "app"),
+                  compression = Symbol(get(preferences, "appimage_compression", "zstd")),
+                  runtime = get(preferences, "appimage_runtime", ""),
+                  windowed = preferences["windowed"],
+                  compress = preferences["compress"],
+                  arch = Sys.ARCH,
+                  parameters = Dict{String, Any}("WINDOWED" => windowed)
+                  )
+
+    depot in APPIMAGE_DEPOTS ||
+        error("`appimage_depot` must be one of: " * join(APPIMAGE_DEPOTS, ", ") * ". Got `$depot`.")
+
+    compression in AppImagePack.COMPRESSORS ||
+        error("`appimage_compression` must be one of: " *
+              join(AppImagePack.COMPRESSORS, ", ") * ". Got `$compression`.")
+
+    # The AppRun template branches on this rather than on the preference string, so the
+    # rendered launcher only carries the lines that apply.
+    parameters["APP_DEPOT"] = depot == "app"
+
+    return AppImage(icon, desktop_launcher, metainfo, main_launcher, startup_file, depot, compression,
+                    isempty(something(runtime, "")) ? nothing : runtime,
+                    windowed, compress, arch, predicate, parameters)
+end
+
+function AppImage(overlay; preferences = preferences(), kwargs...)
+
+    prefix = [overlay, joinpath(overlay, "meta"), joinpath(dirname(@__DIR__), "recipes")]
+    appimage = AppImage(; prefix, preferences, kwargs...)
+    get_bundle_parameters!(appimage.parameters, joinpath(overlay, "Project.toml"); preferences)
+
+    return appimage
+end
+
+function stage(appimage::AppImage, destination::String)
+
+    (; predicate, parameters) = appimage
+    app_name = parameters["APP_NAME"]
+    bundle_identifier = get(parameters, "BUNDLE_IDENTIFIER", app_name)
+
+    # The spec looks for the desktop entry and the icon at the AppDir root, and the `Icon=` key
+    # names the icon with no path and no extension.
+    install(appimage.icon, joinpath(destination, "$app_name.png"))
+    install(appimage.desktop_launcher, joinpath(destination, "$app_name.desktop"); parameters, predicate)
+
+    # `.DirIcon` is what file managers read for the thumbnail. A copy rather than a symlink, since
+    # squashfs preserves symlinks but some extraction paths do not follow them.
+    cp(joinpath(destination, "$app_name.png"), joinpath(destination, ".DirIcon"); force = true)
+
+    # Freedesktop locations, so an AppImage the user installs integrates with the menu
+    install(appimage.icon, joinpath(destination, "usr/share/icons/hicolor/256x256/apps/$app_name.png"))
+    install(appimage.desktop_launcher, joinpath(destination, "usr/share/applications/$app_name.desktop"); parameters, predicate)
+    install(appimage.metainfo, joinpath(destination, "usr/share/metainfo/$bundle_identifier.appdata.xml"); parameters, predicate)
+
+    if !isnothing(appimage.main_launcher)
+        install(appimage.main_launcher, joinpath(destination, "AppRun"); parameters, executable = true, predicate)
+    end
+
+    return
+end
+
+function bundle(setup::Function, appimage::AppImage, destination::String; force = false)
+
+    if ispath(destination)
+        if force
+            rm(destination; force=true, recursive=true)
+        else
+            error("Destination $destination already exists. Use `force = true` argument.")
+        end
+    end
+
+    # Resolve the runtime before doing the expensive staging work, so a missing one fails in
+    # seconds rather than after a full image build.
+    runtime = appimage.compress ? AppImageRuntime.resolve(appimage.arch; runtime = appimage.runtime) : nothing
+
+    appdir = appimage.compress ? mktempdir() : destination
+
+    @info "Initializing AppDir staging layout..."
+    stage(appimage, appdir)
+
+    @info "Installing app into staging area..."
+    setup(appdir)
+
+    if appimage.compress
+        @info "Packaging AppDir into AppImage..."
+        AppImagePack.pack(appdir, destination, runtime; compression = appimage.compression)
     end
 
     return

--- a/src/main.jl
+++ b/src/main.jl
@@ -34,8 +34,9 @@ end
 suffix(msix::MSIX) = msix.compress ? ".msix" : ""
 suffix(dmg::DMG) = dmg.compress ? ".dmg" : ""
 suffix(snap::Snap) = snap.compress ? ".snap" : ""
+suffix(appimage::AppImage) = appimage.compress ? ".AppImage" : ""
 
-function canonical_target_name(spec::Union{MSIX, DMG, Snap})
+function canonical_target_name(spec::Union{MSIX, DMG, Snap, AppImage})
     version = spec.parameters["APP_VERSION"]
     app_name = spec.parameters["APP_NAME"]
     return "$(app_name)-$version-$(spec.arch)"
@@ -130,6 +131,11 @@ function main_build(ARGS; sources_dir)
 
         snap = Snap(sources_dir; arch = target_arch, preferences)
         bundle(spec, snap, target_path(snap); force = overwrite_target)
+
+    elseif :appimage == target_bundle
+
+        appimage = AppImage(sources_dir; arch = target_arch, preferences)
+        bundle(spec, appimage, target_path(appimage); force = overwrite_target)
 
     else
         error("Got unsupported bundle type $target_bundle")
@@ -333,9 +339,14 @@ Options:
   --build-dir DIR                   Output directory for the bundle
                                     (default: temporary directory)
                                     Use '@temp' to explicitly request a temp dir
-  --target-bundle {dmg|snap|msix}   Package format to produce
+  --target-bundle {dmg|snap|appimage|msix}
+                                    Package format to produce
                                     (default: platform native — dmg on macOS,
-                                    snap on Linux, msix on Windows)
+                                    snap on Linux, msix on Windows). `appimage`
+                                    produces a single mountable file, which
+                                    avoids unpacking thousands of files on HPC
+                                    filesystems; it needs an AppImage runtime,
+                                    see -Dappimage_runtime.
   --target-arch {x86_64|aarch64}    Target CPU architecture
                                     (default: current system architecture)
   --target-name NAME                Override the output file/directory name

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -156,3 +156,60 @@ function bundle(product::JuliaCBundle, msix::MSIX, destination::String; password
 
     return
 end
+
+"""
+    bundle(product::JuliaImgBundle, appimage::AppImage, destination::String; force = false)
+
+Stage a Julia application into a mountable AppImage.
+
+The distribution is placed at the AppDir root — `bin/`, `lib/`, `share/`, `etc/` — exactly as the
+Snap target stages it, and `AppRun` execs `bin/julia` from the mount point. Because the mounted
+filesystem is read-only and vanishes when the application exits, the depot is redirected to a
+per-user directory; see the `depot` field of [`AppImage`](@ref).
+"""
+function bundle(product::JuliaImgBundle, appimage::AppImage, destination::String; force = false)
+
+    if !Sys.islinux()
+        @warn "AppImages only run on Linux and the payload is staged for the host platform"
+    end
+
+    bundle(appimage, destination; force) do appdir
+
+        app_name = appimage.parameters["APP_NAME"]
+        bundle_identifier = appimage.parameters["BUNDLE_IDENTIFIER"]
+
+        stage(product, appdir; platform = Linux(appimage.arch), runtime_mode = "SANDBOX", app_name, bundle_identifier)
+
+        # "julia" mode needs a startup file that leaves DEPOT_PATH alone; every set_depot_path_*
+        # in AppEnv begins with `empty!(DEPOT_PATH)`, so AppEnv.init() cannot be used there.
+        startup_file = appimage.depot == "julia" ? appimage.startup_file : product.startup_file
+
+        isnothing(startup_file) &&
+            error("No startup.jl available for `appimage_depot = \"julia\"`.")
+
+        install(startup_file, joinpath(appdir, "etc/julia/startup.jl");
+                parameters = appimage.parameters, force = true)
+    end
+
+    return
+end
+
+"""
+    bundle(product::JuliaCBundle, appimage::AppImage, destination::String; force = false)
+
+Package a juliac-compiled executable as a mountable AppImage.
+"""
+function bundle(product::JuliaCBundle, appimage::AppImage, destination::String; force = false)
+
+    if !Sys.islinux()
+        @warn "AppImages only run on Linux and juliac compiles with the host toolchain"
+    end
+
+    bundle(appimage, destination; force) do appdir
+        app_name = appimage.parameters["APP_NAME"]
+        bundle_identifier = appimage.parameters["BUNDLE_IDENTIFIER"]
+        stage(product, appdir; runtime_mode = "SANDBOX", app_name, bundle_identifier)
+    end
+
+    return
+end

--- a/test/appimage.jl
+++ b/test/appimage.jl
@@ -63,8 +63,12 @@ end
 
     @test AppBundler.suffix(AppImage(APP; compress = false)) == ""
 
-    # A compressor mksquashfs does not have must be rejected before it is invoked, and the
-    # runtime only links squashfuse with zstd and zlib.
+    # The runtime only bundles squashfuse with zstd and zlib. mksquashfs will happily produce xz
+    # and lz4 images, and the runtime then reports "Failed to extract AppImage" — verified against
+    # the upstream runtime — so they are rejected at configuration time rather than shipped.
+    @test AppImage(APP; compression = :gzip).compression == :gzip
+    @test_throws ErrorException AppImage(APP; compression = :xz)
+    @test_throws ErrorException AppImage(APP; compression = :lz4)
     @test_throws ErrorException AppImage(APP; compression = :bzip2)
     @test_throws ErrorException AppImage(APP; depot = "elsewhere")
 end

--- a/test/appimage.jl
+++ b/test/appimage.jl
@@ -1,0 +1,234 @@
+import AppBundler
+import AppBundler: AppImage, bundle, stage, AppImagePack
+
+using Test
+
+const APP = joinpath(pkgdir(AppBundler), "examples", "GtkApp")
+
+"""
+Stand-in for the AppImage runtime. Using a stub keeps these tests free of the network and of
+`AppImageRuntime_jll`.
+
+It has to be a *plausible* 64 bit ELF rather than a blank buffer, because `offset` derives the
+payload position from the section header table exactly as the real runtime does. A stub of zeros
+would let a wrong implementation pass.
+"""
+function stub_runtime(path = tempname(); size = 4096)
+
+    bytes = zeros(UInt8, size)
+    bytes[1:4] = UInt8[0x7f, 0x45, 0x4c, 0x46]  # \x7fELF
+    bytes[5] = 0x02                             # 64 bit
+    bytes[9:11] = UInt8[0x41, 0x49, 0x02]       # AI\x02
+
+    # Section headers placed so that e_shoff + e_shentsize * e_shnum == size, which is what an ELF
+    # whose payload starts immediately afterwards looks like.
+    shentsize, shnum = 64, 1
+    shoff = size - shentsize * shnum
+
+    bytes[41:48] = reinterpret(UInt8, [UInt64(shoff)])
+    bytes[59:60] = reinterpret(UInt8, [UInt16(shentsize)])
+    bytes[61:62] = reinterpret(UInt8, [UInt16(shnum)])
+
+    # The real runtime embeds squashfuse, whose own "hsqs" constant sits some 750 KB before the
+    # actual payload. Reproducing that here keeps `offset` honest: locating the payload by
+    # scanning for the squashfs magic finds this instead and reports a position inside the runtime.
+    bytes[1025:1028] = UInt8[0x68, 0x73, 0x71, 0x73]
+
+    write(path, bytes)
+
+    return path
+end
+
+function fake_payload(root)
+    mkpath(joinpath(root, "bin"))
+    write(joinpath(root, "bin", "julia"), "#!/bin/sh\necho fake julia\n")
+    Sys.isunix() && chmod(joinpath(root, "bin", "julia"), 0o755)
+    return root
+end
+
+@testset "AppImage configuration" begin
+
+    appimage = AppImage(APP; arch = :x86_64)
+
+    @test appimage.arch == :x86_64
+    @test appimage.compress
+    @test appimage.compression == :zstd
+    @test appimage.depot == "app"
+
+    @test AppBundler.suffix(appimage) == ".AppImage"
+
+    # AppImages are conventionally named <App>-<version>-<arch>.AppImage
+    @test AppBundler.canonical_target_name(appimage) ==
+        "$(appimage.parameters["APP_NAME"])-$(appimage.parameters["APP_VERSION"])-x86_64"
+
+    @test AppBundler.suffix(AppImage(APP; compress = false)) == ""
+
+    # A compressor mksquashfs does not have must be rejected before it is invoked, and the
+    # runtime only links squashfuse with zstd and zlib.
+    @test_throws ErrorException AppImage(APP; compression = :bzip2)
+    @test_throws ErrorException AppImage(APP; depot = "elsewhere")
+end
+
+@testset "AppDir staging" begin
+
+    destination = mktempdir()
+    appimage = AppImage(APP; arch = :x86_64)
+    stage(appimage, destination)
+
+    app_name = appimage.parameters["APP_NAME"]
+
+    # AppRun is the entry point the runtime executes after mounting
+    apprun = joinpath(destination, "AppRun")
+    @test isfile(apprun)
+    Sys.isunix() && @test (stat(apprun).mode & 0o111) != 0
+
+    # The spec requires the desktop entry and the icon at the AppDir root
+    @test isfile(joinpath(destination, "$app_name.desktop"))
+    @test isfile(joinpath(destination, "$app_name.png"))
+
+    # `.DirIcon` is what file managers read for the thumbnail
+    dir_icon = joinpath(destination, ".DirIcon")
+    @test ispath(dir_icon)
+    @test read(dir_icon) == read(joinpath(destination, "$app_name.png"))
+
+    # Icon= names the icon without a path or extension, otherwise desktop integration silently
+    # falls back to a generic icon
+    desktop = read(joinpath(destination, "$app_name.desktop"), String)
+    @test occursin("Icon=$app_name\n", desktop)
+    @test !occursin("Icon=$app_name.png", desktop)
+    @test occursin("Type=Application", desktop)
+
+    # Freedesktop copies, so an installed AppImage integrates with the menu
+    @test isfile(joinpath(destination, "usr/share/applications/$app_name.desktop"))
+    @test isfile(joinpath(destination, "usr/share/icons/hicolor/256x256/apps/$app_name.png"))
+
+    bundle_id = appimage.parameters["BUNDLE_IDENTIFIER"]
+    @test isfile(joinpath(destination, "usr/share/metainfo/$bundle_id.appdata.xml"))
+end
+
+@testset "Packing an AppImage" begin
+
+    appdir = mktempdir()
+    stage(AppImage(APP; arch = :x86_64), appdir)
+    fake_payload(appdir)
+
+    runtime = stub_runtime()
+    destination = joinpath(mktempdir(), "Demo-x86_64.AppImage")
+
+    AppImagePack.pack(appdir, destination, runtime; compression = :zstd)
+
+    @test isfile(destination)
+
+    # An AppImage is the runtime followed by the squashfs, so the file must begin with the
+    # runtime byte for byte and carry the magic at offset 8.
+    prefix = read(runtime)
+    @test read(destination)[1:length(prefix)] == prefix
+    @test read(destination)[9:11] == UInt8[0x41, 0x49, 0x02]
+
+    # The payload starts exactly where the runtime ends; this is what `--appimage-offset` reports.
+    # The stub embeds a decoy "hsqs" the way the real runtime does, so a scan-based
+    # implementation would report a position inside the runtime instead.
+    @test AppImagePack.offset(destination) == filesize(runtime)
+    @test AppImagePack.offset(destination) > 1028
+    @test filesize(destination) > filesize(runtime)
+
+    Sys.isunix() && @test (stat(destination).mode & 0o111) != 0
+
+    # Reading the payload back without FUSE is the escape hatch for a site that cannot mount
+    extracted = mktempdir()
+    AppImagePack.unpack(destination, extracted)
+
+    @test isfile(joinpath(extracted, "AppRun"))
+    @test isfile(joinpath(extracted, "bin", "julia"))
+end
+
+@testset "Runtime resolution" begin
+
+    runtime = stub_runtime()
+
+    # An explicit path wins over everything else
+    @test AppBundler.AppImageRuntime.resolve(:x86_64; runtime) == runtime
+
+    @test_throws ErrorException AppBundler.AppImageRuntime.resolve(:x86_64;
+                                                                  runtime = "/no/such/runtime")
+
+    # With nothing available the error has to name both remedies, since this is the one step
+    # that fails for a reason outside the user's own project.
+    message = try
+        AppBundler.AppImageRuntime.resolve(:x86_64; runtime = nothing, allow_jll = false)
+        ""
+    catch err
+        sprint(showerror, err)
+    end
+
+    @test occursin("AppImageRuntime_jll", message)
+    @test occursin("appimage_runtime", message)
+end
+
+@testset "AppImage bundle round trip" begin
+
+    appimage = AppImage(APP; arch = :x86_64, runtime = stub_runtime())
+    destination = joinpath(mktempdir(), "$(AppBundler.canonical_target_name(appimage)).AppImage")
+
+    bundle(appimage, destination) do appdir
+        fake_payload(appdir)
+    end
+
+    @test isfile(destination)
+    @test AppImagePack.offset(destination) == filesize(appimage.runtime)
+
+    extracted = mktempdir()
+    AppImagePack.unpack(destination, extracted)
+    @test isfile(joinpath(extracted, "bin", "julia"))
+    @test isfile(joinpath(extracted, "AppRun"))
+
+    # Refuses to clobber unless asked
+    @test_throws ErrorException bundle(identity, appimage, destination)
+    bundle(identity, appimage, destination; force = true)
+    @test isfile(destination)
+end
+
+@testset "AppRun depot selection" begin
+
+    app_scoped = mktempdir()
+    stage(AppImage(APP; arch = :x86_64, depot = "app"), app_scoped)
+    apprun = read(joinpath(app_scoped, "AppRun"), String)
+
+    # Default: a persistent per-user depot that never touches the host ~/.julia
+    @test occursin("USER_DATA", apprun)
+    @test occursin("XDG_DATA_HOME", apprun)
+    @test !occursin(".julia", apprun)
+
+    stock = mktempdir()
+    appimage = AppImage(APP; arch = :x86_64, depot = "julia")
+    stage(appimage, stock)
+    apprun = read(joinpath(stock, "AppRun"), String)
+
+    # `julia` mode leaves the depot alone so HPC users keep their existing environments
+    @test !occursin("USER_DATA=", apprun)
+
+    # That mode swaps in a startup file which sets up the load path without replacing
+    # DEPOT_PATH. It is only ever executed on the target machine, so at least confirm here that
+    # it renders to parseable Julia and calls the AppEnv entry points it relies on.
+    @test !isnothing(appimage.startup_file)
+
+    rendered = joinpath(mktempdir(), "startup.jl")
+    AppBundler.install(appimage.startup_file, rendered; parameters = appimage.parameters)
+    source = read(rendered, String)
+
+    @test Meta.parse("begin\n" * source * "\nend") isa Expr
+    @test occursin("set_load_path!", source)
+    @test occursin("load_config", source)
+
+    # AppEnv.init() would replace DEPOT_PATH, which is exactly what this mode avoids. Comments
+    # are stripped first, since the file explains that reasoning in prose.
+    code = join((first(split(line, '#')) for line in split(source, '\n')), "\n")
+    @test !occursin("AppEnv.init()", code)
+
+    # The startup file calls these directly, so a rename upstream should fail here rather than on
+    # a user's machine at launch.
+    import AppEnv
+    for name in [:load_config, :set_load_path!, :load_pkgorigins!]
+        @test isdefined(AppEnv, name)
+    end
+end

--- a/test/appimage_e2e.jl
+++ b/test/appimage_e2e.jl
@@ -1,0 +1,88 @@
+# End to end check against a real AppImage runtime.
+#
+# Opt in with JULIA_RUN_APPIMAGE_E2E=true and point APPIMAGE_RUNTIME at a runtime binary (see
+# https://github.com/AppImage/type2-runtime/releases), or install AppImageRuntime_jll once it is
+# registered.
+#
+# Note that mounting requires `fusermount` on the host. Where it is missing the runtime says so and
+# falls back to --appimage-extract-and-run, which exercises the same AppRun and payload; only the
+# mount call itself goes untested.
+
+import AppBundler
+import AppBundler: AppImage, AppImagePack, bundle, stage, JuliaImgBundle
+
+using Test
+
+const APP = joinpath(pkgdir(AppBundler), "examples", "CmdApp")
+
+function available_runtime()
+
+    path = get(ENV, "APPIMAGE_RUNTIME", "")
+    isempty(path) || return isfile(path) ? path : nothing
+
+    return AppBundler.AppImageRuntime.jll_runtime(Sys.ARCH)
+end
+
+runtime = available_runtime()
+
+if !Sys.islinux()
+    @info "Skipping AppImage end to end test: Linux required"
+elseif isnothing(runtime)
+    @info "Skipping AppImage end to end test: set APPIMAGE_RUNTIME or install AppImageRuntime_jll"
+else
+
+    appimage = AppImage(APP; arch = Sys.ARCH, runtime, preferences = merge(
+        AppBundler.Resources.get_project_preferences(APP)["AppBundler"],
+        Dict("bundler" => "juliaimg")))
+
+    destination = joinpath(mktempdir(), "$(AppBundler.canonical_target_name(appimage)).AppImage")
+
+    product = JuliaImgBundle(APP; precompile = false)
+
+    bundle(product, appimage, destination)
+
+    @testset "The AppImage is well formed" begin
+
+        @test isfile(destination)
+        @test (stat(destination).mode & 0o111) != 0
+
+        # The runtime reports the payload offset it will mount at; it has to agree with what we
+        # computed, otherwise the runtime and AppBundler disagree about where the filesystem is.
+        reported = parse(Int, strip(read(`$destination --appimage-offset`, String)))
+        @test reported == AppImagePack.offset(destination)
+        @test reported == filesize(runtime)
+    end
+
+    @testset "The payload carries a Julia distribution" begin
+
+        extracted = mktempdir()
+        AppImagePack.unpack(destination, extracted)
+
+        @test isfile(joinpath(extracted, "AppRun"))
+        @test isfile(joinpath(extracted, "bin", "julia"))
+        @test isfile(joinpath(extracted, "etc", "julia", "startup.jl"))
+        @test isdir(joinpath(extracted, "share", "julia"))
+    end
+
+    @testset "The application runs out of the AppImage" begin
+
+        # CmdApp prints its own LOAD_PATH, DEPOT_PATH, Sys.BINDIR and USER_DATA, which is what
+        # makes it possible to check that the depot decision actually took effect on the far side.
+        data_home = mktempdir()
+
+        env = copy(ENV)
+        env["XDG_DATA_HOME"] = data_home
+        delete!(env, "USER_DATA")
+
+        # --appimage-extract-and-run avoids needing fusermount, while still going through the
+        # runtime and AppRun exactly as a mounted run would.
+        output = read(ignorestatus(setenv(`$destination --appimage-extract-and-run`,
+                                          env; dir = mktempdir())), String)
+
+        @test occursin("Sys.BINDIR", output)
+
+        # The default "app" depot: persistent, per user, and never the host's ~/.julia
+        @test occursin(joinpath(data_home, "cmdapp"), output)
+        @test !occursin(joinpath(homedir(), ".julia") * ",", output)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,8 +16,18 @@ end
     include("juliac.jl")
 end
 
+@time @safetestset "AppImage tests" begin
+    include("appimage.jl")
+end
+
 @time @safetestset "CLI API example" begin
     include("integrity.jl")
+end
+
+if get(ENV, "JULIA_RUN_APPIMAGE_E2E", "false") == "true"
+    @time @safetestset "AppImage end to end" begin
+        include("appimage_e2e.jl")
+    end
 end
 
 if get(ENV, "JULIA_RUN_EXAMPLES", "false") == "true"


### PR DESCRIPTION
Closes #42.

An AppImage is mounted rather than installed, so a bundled Julia distribution never writes its tens of thousands of files to disk. That cost — the hydration problem you raised — is what makes the other formats impractical on HPC filesystems.

You were right that `mksquashfs` does most of the work. The format turns out to be nothing more than a runtime ELF followed by a squashfs image, so the remaining work was the AppDir layout, the desktop and AppStream metadata, and getting hold of the runtime.

```
appbundler build . --target-bundle=appimage --build-dir=build
```

## The depot question

You left this open in the issue, so it is a `appimage_depot` preference rather than a decision baked in:

- **`"app"`** (default) — `AppRun` points `USER_DATA` at `$XDG_DATA_HOME/<app>`. The mounted filesystem is read-only and disappears when the application exits, so the depot has to live somewhere; this gives a persistent per-user one and never touches the host's `~/.julia`.
- **`"julia"`** — what you floated in the issue: the stock depot, left as Julia found it, with the bundled `share/julia` appended so the shipped packages stay resolvable. This needs its own `startup.jl`, because every `set_depot_path_*` in AppEnv begins with `empty!(DEPOT_PATH)`, so `AppEnv.init()` cannot be used in that mode.

## The runtime

This is the one part that is not self-contained. The runtime is a ~900 KB static-PIE ELF, and there is no jll: it links `libsquashfuse`, `libsquashfuse_ll`, `libfuse3`, `libzstd`, `libz` and `libmimalloc`, and **Yggdrasil has `mimalloc`, `Zstd` and `Zlib` but neither `squashfuse` nor `libfuse`**. Packaging it properly is three recipes, and the artifact also sits awkwardly in Yggdrasil's model — it is keyed only by target CPU architecture and must run on any Linux, rather than following the glibc/musl platform split.

So the source is pluggable: an explicit path or the `appimage_runtime` preference today, `AppImageRuntime_jll` automatically once it exists. That Yggdrasil work is being prepared separately and does not block this. Until then the error message names both remedies, since this is the one step that fails for a reason outside the user's own project.

## Two details worth flagging in review

**`offset` reads the ELF section header table, not the squashfs magic.** My first implementation scanned for `hsqs` and was wrong: the runtime embeds squashfuse, whose own `hsqs` constant sits at byte 194183 — some 750 KB before the real payload. The end-to-end test caught it because the runtime's `--appimage-offset` reported 944632 and mine reported 194183. The unit test had passed only because its stub runtime was a blank buffer, so the stub now embeds a decoy `hsqs` and is a plausible ELF.

**`pack` writes into the output file after a reserved prefix.** `mksquashfs -offset` reserves room for the runtime, which then goes in over it — `-offset` zeroes the skipped bytes rather than preserving them, so the order matters. Building the squashfs separately and concatenating would need a second full-size temporary copy: for a Julia distribution that is hundreds of megabytes, usually landing in `/tmp`, and `mksquashfs` reports exhaustion only as `FATAL ERROR: Probably out of space on output filesystem`. I hit exactly that while developing, so the docs also note the build-time space requirement.

## Verification

`test/appimage.jl` — 52 assertions with a stub runtime, so no network and no jll: AppDir layout (the `Icon=` key naming the icon with no path or extension, `.DirIcon`, the freedesktop copies), offset and round-trip through `unpack`, compressor and depot validation, runtime resolution, and that the `"julia"`-mode `startup.jl` renders to parseable Julia which calls the AppEnv entry points it depends on rather than `AppEnv.init()`.

`test/appimage_e2e.jl` — opt-in (`JULIA_RUN_APPIMAGE_E2E=true`, `APPIMAGE_RUNTIME=<path>`), against a real runtime and the `CmdApp` example:

- the runtime's own `--appimage-offset` agrees with `AppImagePack.offset`;
- the payload holds a real distribution (5222 files, 882 directories, 74 symlinks);
- the application runs, and `CmdApp`'s own environment dump shows the depot landing under `XDG_DATA_HOME`, which is what actually proves the depot decision works — it precompiles into that depot on first launch.

`test/bundle.jl` (MSIX, DMG, Snap) still passes, and the docs build warning-free.

**Not verified here: mounting.** This machine has `/dev/fuse` but no `fusermount`, so the e2e test uses `--appimage-extract-and-run`, which goes through the same runtime and `AppRun` but extracts first. The mount call itself is the one untested step — and since mounting is the whole point for HPC, that gap is worth someone confirming on a machine with FUSE before this is relied on.

The FUSE requirement is documented, along with the no-FUSE fallback: the payload is an ordinary squashfs at a known offset, so `AppBundler.AppImagePack.unpack` (or `unsquashfs -o $(app --appimage-offset)`) reads it without the runtime at all.

## Also included

`bundle(::Function, ::MSIX, ::String)` had an empty docstring that rendered blank in the manual; it now has one. A `CHANGELOG.md` and a `justfile` are added, per the conventions I work to — happy to drop either if you would rather they came separately.

Assisted-by: AI
